### PR TITLE
Reduce DB queries for seo url links

### DIFF
--- a/upload/catalog/controller/common/seo_url.php
+++ b/upload/catalog/controller/common/seo_url.php
@@ -1,6 +1,15 @@
 <?php
 class ControllerCommonSeoUrl extends Controller {
 
+	private $db;
+
+	public function __construct($registry)
+	{
+		parent::__construct($registry);
+
+		$this->db = new DbMemoryCacheDecorator($registry->get('db'));
+	}
+
 	public function index() {
 		// Add rewrite to url class
 		if ($this->config->get('config_seo_url')) {

--- a/upload/system/library/dbMemoryCacheDecorator.php
+++ b/upload/system/library/dbMemoryCacheDecorator.php
@@ -1,0 +1,42 @@
+<?php
+
+class DbMemoryCacheDecorator
+{
+    private $db;
+    private static $results = array();
+    private static $escaped = array();
+
+    public function __construct($db)
+    {
+        $this->db = $db;
+    }
+
+    public function query($sql)
+    {
+        $h = md5($sql);
+        if (!isset(self::$results[$h])) {
+            self::$results[$h] = $this->db->query($sql);
+        }
+
+        return self::$results[$h];
+    }
+
+    public function escape($string)
+    {
+        if (!isset(self::$escaped[$string])) {
+            self::$escaped[$string] = $this->db->escape($string);
+        }
+
+        return self::$escaped[$string];
+    }
+
+    public function countAffected()
+    {
+        return $this->db->countAffected();
+    }
+
+    public function getLastId()
+    {
+        return $this->db->getLastId();
+    }
+}

--- a/upload/system/startup.php
+++ b/upload/system/startup.php
@@ -107,6 +107,7 @@ require_once(DIR_SYSTEM . 'library/cache.php');
 require_once(DIR_SYSTEM . 'library/url.php');
 require_once(DIR_SYSTEM . 'library/config.php');
 require_once(DIR_SYSTEM . 'library/db.php');
+require_once(DIR_SYSTEM . 'library/DbMemoryCacheDecorator.php');
 require_once(DIR_SYSTEM . 'library/document.php');
 require_once(DIR_SYSTEM . 'library/encryption.php');
 require_once(DIR_SYSTEM . 'library/image.php');

--- a/upload/system/startup.php
+++ b/upload/system/startup.php
@@ -107,7 +107,7 @@ require_once(DIR_SYSTEM . 'library/cache.php');
 require_once(DIR_SYSTEM . 'library/url.php');
 require_once(DIR_SYSTEM . 'library/config.php');
 require_once(DIR_SYSTEM . 'library/db.php');
-require_once(DIR_SYSTEM . 'library/DbMemoryCacheDecorator.php');
+require_once(DIR_SYSTEM . 'library/dbMemoryCacheDecorator.php');
 require_once(DIR_SYSTEM . 'library/document.php');
 require_once(DIR_SYSTEM . 'library/encryption.php');
 require_once(DIR_SYSTEM . 'library/image.php');


### PR DESCRIPTION
The [desktops category](http://demo.villagedefrance.net/desktops) page uses 268 database queries that originate from ControllerCommonSeoUrl::rewrite() method in order to find an url alias for a given route. Only 80 of these queries are unique. This pull requests introduces a database decorator class, which computes md5 for every query that goes through it and caches the results in array, so that the subsequent calls with the same hash are returned from memory, instead of querying database server.
Therefore, only 80 queries get executed for the above mentioned page. 