### PR TITLE
Seo url file cache

### DIFF
--- a/upload/index.php
+++ b/upload/index.php
@@ -239,6 +239,12 @@ if (isset($request->get['route'])) {
 // Dispatch
 $controller->dispatch($action, new Action('error/not_found'));
 
+if ($url_map = $registry->get('save_seo_url_map')) {
+	$cache_key = 'seo_url_map_' . $config->get('config_language');
+	$cache->delete($cache_key);
+	$cache->set($cache_key, $registry->get('seo_url_map'));
+}
+
 // Output
 $response->output();
 ?>


### PR DESCRIPTION
This commit further reduces the database queries for url aliases (it actually removes the need for queries once the cache is populated).
It builds an url map on demand and saves it as a file. The map gets expanded on every requests until it is filled up with every existing url alias. 

This commit is not 100% finished as I didn't implement a turn on/off feature in the admin panel:
```php
if (true || $this->config->get('config_seo_url_cache')) {
```
I am also not 100% sure if index.php is the right place to save the url map in the cache. It should happen just before the buffer output.

Please, review and let me know what you think.
