### PR TITLE
Filemanager repairs

### DIFF
--- a/upload/admin/controller/common/filemanager.php
+++ b/upload/admin/controller/common/filemanager.php
@@ -218,7 +218,7 @@ class ControllerCommonFileManager extends Controller {
 
 					$json[] = array(
 						'filename' 	=> htmlspecialchars(basename($file), ENT_QUOTES, 'UTF-8'),
-					    'file'  	=> $filename_pathd,
+						'file'  	=> $filename_pathd,
 						'size'     	=> round(utf8_substr($size, 0, utf8_strpos($size, '.') + 4), 2) . $suffix[$i],
 						'image'     => $this->image($filename_pathd) // call image directly, use pathd for the sake of subdirs
 					);

--- a/upload/admin/controller/common/filemanager.php
+++ b/upload/admin/controller/common/filemanager.php
@@ -80,35 +80,54 @@ class ControllerCommonFileManager extends Controller {
 		$this->response->setOutput($this->render());
 	}
 
-	public function image() {
+	public function image($filename = '') { // added filename argument for local use
 		$this->load->model('tool/image');
 
 		$this->data['token'] = $this->session->data['token'];
 
-		if (isset($this->request->get['image'])) {
-			$ext = utf8_substr(strrchr($this->request->get['image'], '.'), 1);
+		// set return mode
+		$return = true;
 
-			if (strtolower($ext) == 'pdf') {
-				$this->request->get['image'] = 'pdf.png';
-			}
+		// check for image request param and change to render mode
+		if (!empty($this->request->get['image']))  {
+			$filename = $this->request->get['image'];
+			$return = false;
+		}
 
-			if (strtolower($ext) == 'flv') {
-				$this->request->get['image'] = 'flv.png';
-			}
+		// do some filters here in case something passes messy in this mess
+		if (strpos($filename, 'data/') == false) {
+			$filename = 'data/' . $filename;
+		}
+		$filename = str_replace('//', '/', $filename);
+		$filename = str_replace('data/data', 'data', $filename);
 
-			if (strtolower($ext) == 'swf') {
-				$this->request->get['image'] = 'swf.png';
-			}
+		$ext = utf8_substr(strrchr($filename, '.'), 1);
 
-			if (strtolower($ext) == 'zip') {
-				$this->request->get['image'] = 'zip.png';
-			}
+		if (strtolower($ext) == 'pdf') {
+			$filename = 'pdf.png';
+		}
 
-			if (strtolower($ext) == 'rar') {
-				$this->request->get['image'] = 'rar.png';
-			}
+		if (strtolower($ext) == 'flv') {
+			$filename = 'flv.png';
+		}
 
-			$this->response->setOutput(htmlspecialchars($this->model_tool_image->resize(html_entity_decode($this->request->get['image'], ENT_QUOTES, 'UTF-8'), 100, 100), ENT_QUOTES, 'UTF-8'));
+		if (strtolower($ext) == 'swf') {
+			$filename = 'swf.png';
+		}
+
+		if (strtolower($ext) == 'zip') {
+			$filename = 'zip.png';
+		}
+
+		if (strtolower($ext) == 'rar') {
+			$filename = 'rar.png';
+		}
+		
+		// mode: return or render
+		if ($return) {
+			return htmlspecialchars($this->model_tool_image->resize(html_entity_decode($filename, ENT_QUOTES, 'UTF-8'), 100, 100), ENT_QUOTES, 'UTF-8');
+		} else {
+			$this->response->setOutput(htmlspecialchars($this->model_tool_image->resize(html_entity_decode($filename, ENT_QUOTES, 'UTF-8'), 100, 100), ENT_QUOTES, 'UTF-8'));
 		}
 	}
 
@@ -195,10 +214,13 @@ class ControllerCommonFileManager extends Controller {
 						$i++;
 					}
 
+					$filename_pathd = htmlspecialchars(utf8_substr($file, utf8_strlen(DIR_IMAGE . 'data/')), ENT_QUOTES, 'UTF-8');
+
 					$json[] = array(
-						'filename'	=> htmlspecialchars(basename($file), ENT_QUOTES, 'UTF-8'),
-						'file'			=> htmlspecialchars(utf8_substr($file, utf8_strlen(DIR_IMAGE . 'data/')), ENT_QUOTES, 'UTF-8'),
-						'size'			=> round(utf8_substr($size, 0, utf8_strpos($size, '.') + 4), 2) . $suffix[$i]
+						'filename' 	=> htmlspecialchars(basename($file), ENT_QUOTES, 'UTF-8'),
+					    'file'  	=> $filename_pathd,
+						'size'     	=> round(utf8_substr($size, 0, utf8_strpos($size, '.') + 4), 2) . $suffix[$i],
+						'image'     => $this->image($filename_pathd) // call image directly, use pathd for the sake of subdirs
 					);
 				}
 			}

--- a/upload/admin/controller/common/filemanager_full.php
+++ b/upload/admin/controller/common/filemanager_full.php
@@ -96,35 +96,54 @@ class ControllerCommonFileManagerFull extends Controller {
 		$this->response->setOutput($this->render());
 	}
 
-	public function image() {
+	public function image($filename = '') { // added filename argument for local use
 		$this->load->model('tool/image');
 
 		$this->data['token'] = $this->session->data['token'];
 
-		if (isset($this->request->get['image'])) {
-			$ext = utf8_substr(strrchr($this->request->get['image'], '.'), 1);
+		// set return mode
+		$return = true;
 
-			if (strtolower($ext) == 'pdf') {
-				$this->request->get['image'] = 'pdf.png';
-			}
+		// check for image request param and change to render mode
+		if (!empty($this->request->get['image']))  {
+			$filename = $this->request->get['image'];
+			$return = false;
+		}
 
-			if (strtolower($ext) == 'flv') {
-				$this->request->get['image'] = 'flv.png';
-			}
+		// do some filters here in case something passes messy in this mess
+		if (strpos($filename, 'data/') == false) {
+			$filename = 'data/' . $filename;
+		}
+		$filename = str_replace('//', '/', $filename);
+		$filename = str_replace('data/data', 'data', $filename);
 
-			if (strtolower($ext) == 'swf') {
-				$this->request->get['image'] = 'swf.png';
-			}
+		$ext = utf8_substr(strrchr($filename, '.'), 1);
 
-			if (strtolower($ext) == 'zip') {
-				$this->request->get['image'] = 'zip.png';
-			}
+		if (strtolower($ext) == 'pdf') {
+			$filename = 'pdf.png';
+		}
 
-			if (strtolower($ext) == 'rar') {
-				$this->request->get['image'] = 'rar.png';
-			}
+		if (strtolower($ext) == 'flv') {
+			$filename = 'flv.png';
+		}
 
-			$this->response->setOutput(htmlspecialchars($this->model_tool_image->resize(html_entity_decode($this->request->get['image'], ENT_QUOTES, 'UTF-8'), 100, 100), ENT_QUOTES, 'UTF-8'));
+		if (strtolower($ext) == 'swf') {
+			$filename = 'swf.png';
+		}
+
+		if (strtolower($ext) == 'zip') {
+			$filename = 'zip.png';
+		}
+
+		if (strtolower($ext) == 'rar') {
+			$filename = 'rar.png';
+		}
+		
+		// mode: return or render
+		if ($return) {
+			return htmlspecialchars($this->model_tool_image->resize(html_entity_decode($filename, ENT_QUOTES, 'UTF-8'), 100, 100), ENT_QUOTES, 'UTF-8');
+		} else {
+			$this->response->setOutput(htmlspecialchars($this->model_tool_image->resize(html_entity_decode($filename, ENT_QUOTES, 'UTF-8'), 100, 100), ENT_QUOTES, 'UTF-8'));
 		}
 	}
 
@@ -211,10 +230,13 @@ class ControllerCommonFileManagerFull extends Controller {
 						$i++;
 					}
 
+					$filename_pathd = htmlspecialchars(utf8_substr($file, utf8_strlen(DIR_IMAGE . 'data/')), ENT_QUOTES, 'UTF-8');
+
 					$json[] = array(
-						'filename'	=> htmlspecialchars(basename($file), ENT_QUOTES, 'UTF-8'),
-						'file'			=> htmlspecialchars(utf8_substr($file, utf8_strlen(DIR_IMAGE . 'data/')), ENT_QUOTES, 'UTF-8'),
-						'size'			=> round(utf8_substr($size, 0, utf8_strpos($size, '.') + 4), 2) . $suffix[$i]
+						'filename' 	=> htmlspecialchars(basename($file), ENT_QUOTES, 'UTF-8'),
+						'file'  	=> $filename_pathd,
+						'size'     	=> round(utf8_substr($size, 0, utf8_strpos($size, '.') + 4), 2) . $suffix[$i],
+						'image'     => $this->image($filename_pathd) // call image directly, use pathd for the sake of subdirs
 					);
 				}
 			}

--- a/upload/admin/view/template/common/filemanager.tpl
+++ b/upload/admin/view/template/common/filemanager.tpl
@@ -113,7 +113,7 @@ $(document).ready(function() {
 								html += '<div class="feedback"><?php echo $text_no_file_found; ?></div>';
 							} else {
 								for (i = 0; i < json.length; i++) {
-									html += '<a file="' + json[i]['file'] + '" style="display:none; float:left;" title="' + json[i]['filename'] + '"><span class="fileName">' + ((json[i]['filename'].length > 16) ? (json[i]['filename'].substr(0, 16) + '..') : json[i]['filename']) + '</span><span class="fileSize">' + json[i]['size'] + '</span><input type="hidden" name="image" value="' + json[i]['file'] + '" /></a>';
+									html += '<a file="' + json[i]['file'] + '" style="float:left;" title="' + json[i]['filename'] + '"><img src="' + json[i]['image'] + '" title="" alt="" /><span class="fileName">' + ((json[i]['filename'].length > 16) ? (json[i]['filename'].substr(0, 16) + '..') : json[i]['filename']) + '</span><span class="fileSize">' + json[i]['size'] + '</span><input type="hidden" name="image" value="' + json[i]['file'] + '" /></a>';
 								}
 							}
 						}
@@ -121,16 +121,6 @@ $(document).ready(function() {
 
 						$('#column-right').html(html);
 
-						$('#column-right a').each(function(index, element) {
-							$.ajax({
-								url: 'index.php?route=common/filemanager/image&token=<?php echo $token; ?>&image=' + encodeURIComponent('data/' + $(element).find('input[name=\'image\']').attr('value')),
-								dataType: 'html',
-								success: function(html) {
-									$(element).prepend('<img src="' + html + '" title="" alt="" /><br />');
-									$(element).fadeIn(60);
-								}
-							});
-						});
 					},
 					error: function(xhr, ajaxOptions, thrownError) {
 						alert(thrownError + "\r\n" + xhr.statusText + "\r\n" + xhr.responseText);

--- a/upload/admin/view/template/common/filemanager_full.tpl
+++ b/upload/admin/view/template/common/filemanager_full.tpl
@@ -118,7 +118,7 @@ $(document).ready(function() {
 								html += '<div class="feedback"><?php echo $text_no_file_found; ?></div>';
 							} else {
 								for (i = 0; i < json.length; i++) {
-									html += '<a file="' + json[i]['file'] + '" style="display:none; float:left;" title="' + json[i]['filename'] + '"><span class="fileName">' + ((json[i]['filename'].length > 16) ? (json[i]['filename'].substr(0, 16) + '..') : json[i]['filename']) + '</span><span class="fileSize">' + json[i]['size'] + '</span><input type="hidden" name="image" value="' + json[i]['file'] + '" /></a>';
+									html += '<a file="' + json[i]['file'] + '" style="float:left;" title="' + json[i]['filename'] + '"><img src="' + json[i]['image'] + '" title="" alt="" /><span class="fileName">' + ((json[i]['filename'].length > 16) ? (json[i]['filename'].substr(0, 16) + '..') : json[i]['filename']) + '</span><span class="fileSize">' + json[i]['size'] + '</span><input type="hidden" name="image" value="' + json[i]['file'] + '" /></a>';
 								}
 							}
 						}
@@ -126,16 +126,6 @@ $(document).ready(function() {
 
 						$('#column-right').html(html);
 
-						$('#column-right a').each(function(index, element) {
-							$.ajax({
-								url: 'index.php?route=common/filemanager_full/image&token=<?php echo $token; ?>&image=' + encodeURIComponent('data/' + $(element).find('input[name=\'image\']').attr('value')),
-								dataType: 'html',
-								success: function(html) {
-									$(element).prepend('<img src="' + html + '" title="" alt="" /><br />');
-									$(element).fadeIn(60);
-								}
-							});
-						});
 					},
 					error: function(xhr, ajaxOptions, thrownError) {
 						alert(thrownError + "\r\n" + xhr.statusText + "\r\n" + xhr.responseText);


### PR DESCRIPTION
Filemanager is now like 1000000x faster at loading items.

 - added a way for files() to use image() directly
 - allow image() to still return a render
 - files() passes 'image' index to tpl
 - tpl puts image in during first loop
 - removed other unnecessary loop calling for images (that was very slow)

Hope it works well for ya all. Our store has many images and this was needed.