### PR TITLE
New marketing entry

### DIFF
--- a/upload/admin/controller/common/header.php
+++ b/upload/admin/controller/common/header.php
@@ -153,6 +153,9 @@ class ControllerCommonHeader extends Controller {
 		$this->data['text_report_customer_credit'] = $this->language->get('text_report_customer_credit');
 		$this->data['text_report_customer_country'] = $this->language->get('text_report_customer_country');
 		$this->data['text_report_customer_online'] = $this->language->get('text_report_customer_online');
+		$this->data['text_report_marketing'] = $this->language->get('text_report_marketing');
+//disconnected		$this->data['text_report_affiliate'] = $this->language->get('text_report_affiliate');
+//disconnected		$this->data['text_report_affiliate_activity'] = $this->language->get('text_report_affiliate_activity');
 		$this->data['text_report_affiliate_commission'] = $this->language->get('text_report_affiliate_commission');
 		$this->data['text_report_sale_return'] = $this->language->get('text_report_sale_return');
 		$this->data['text_report_product_viewed'] = $this->language->get('text_report_product_viewed');
@@ -214,6 +217,7 @@ class ControllerCommonHeader extends Controller {
 			$this->data['logged'] = sprintf($this->language->get('text_logged'), $this->user->getUserName());
 
 			$this->data['affiliate'] = $this->url->link('sale/affiliate', 'token=' . $this->session->data['token'], 'SSL');
+//disconnected			$this->data['affiliate'] = $this->url->link('marketing/affiliate', 'token=' . $this->session->data['token'], 'SSL');
 			$this->data['api_key_manager'] = $this->url->link('tool/api_key_manager', 'token=' . $this->session->data['token'], 'SSL');
 			$this->data['attribute'] = $this->url->link('catalog/attribute', 'token=' . $this->session->data['token'], 'SSL');
 			$this->data['attribute_group'] = $this->url->link('catalog/attribute_group', 'token=' . $this->session->data['token'], 'SSL');
@@ -226,8 +230,10 @@ class ControllerCommonHeader extends Controller {
 			$this->data['configuration'] = $this->url->link('tool/configuration', 'token=' . $this->session->data['token'], 'SSL');
 			$this->data['connection'] = $this->url->link('design/connection', 'token=' . $this->session->data['token'], 'SSL');
 			$this->data['contact'] = $this->url->link('sale/contact', 'token=' . $this->session->data['token'], 'SSL');
+//disconnected			$this->data['contact'] = $this->url->link('marketing/contact', 'token=' . $this->session->data['token'], 'SSL');
 			$this->data['country'] = $this->url->link('localisation/country', 'token=' . $this->session->data['token'], 'SSL');
 			$this->data['coupon'] = $this->url->link('sale/coupon', 'token=' . $this->session->data['token'], 'SSL');
+//disconnected			$this->data['coupon'] = $this->url->link('marketing/coupon', 'token=' . $this->session->data['token'], 'SSL');
 			$this->data['currency'] = $this->url->link('localisation/currency', 'token=' . $this->session->data['token'], 'SSL');
 			$this->data['customer'] = $this->url->link('sale/customer', 'token=' . $this->session->data['token'], 'SSL');
 			$this->data['customer_group'] = $this->url->link('sale/customer_group', 'token=' . $this->session->data['token'], 'SSL');
@@ -286,6 +292,9 @@ class ControllerCommonHeader extends Controller {
 			$this->data['report_customer_credit'] = $this->url->link('report/customer_credit', 'token=' . $this->session->data['token'], 'SSL');
 			$this->data['report_customer_country'] = $this->url->link('report/customer_country', 'token=' . $this->session->data['token'], 'SSL');
 			$this->data['report_customer_online'] = $this->url->link('report/customer_online', 'token=' . $this->session->data['token'], 'SSL');
+			$this->data['report_marketing'] = $this->url->link('report/marketing', 'token=' . $this->session->data['token'], 'SSL');
+//disconnected			$this->data['report_affiliate'] = $this->url->link('report/affiliate', 'token=' . $this->session->data['token'], 'SSL');
+//disconnected			$this->data['report_affiliate_activity'] = $this->url->link('report/affiliate_activity', 'token=' . $this->session->data['token'], 'SSL');
 			$this->data['report_affiliate_commission'] = $this->url->link('report/affiliate_commission', 'token=' . $this->session->data['token'], 'SSL');
 			$this->data['review'] = $this->url->link('catalog/review', 'token=' . $this->session->data['token'], 'SSL');
 			$this->data['return'] = $this->url->link('sale/return', 'token=' . $this->session->data['token'], 'SSL');

--- a/upload/admin/controller/common/header.php
+++ b/upload/admin/controller/common/header.php
@@ -115,6 +115,7 @@ class ControllerCommonHeader extends Controller {
 		$this->data['text_logout'] = $this->language->get('text_logout');
 		$this->data['text_logs'] = $this->language->get('text_logs');
 		$this->data['text_manufacturer'] = $this->language->get('text_manufacturer');
+		$this->data['text_marketing'] = $this->language->get('text_marketing');
 		$this->data['text_menu_manager'] = $this->language->get('text_menu_manager');
 		$this->data['text_modification'] = $this->language->get('text_modification');
 		$this->data['text_module'] = $this->language->get('text_module');
@@ -154,8 +155,8 @@ class ControllerCommonHeader extends Controller {
 		$this->data['text_report_customer_country'] = $this->language->get('text_report_customer_country');
 		$this->data['text_report_customer_online'] = $this->language->get('text_report_customer_online');
 		$this->data['text_report_marketing'] = $this->language->get('text_report_marketing');
-//disconnected		$this->data['text_report_affiliate'] = $this->language->get('text_report_affiliate');
-//disconnected		$this->data['text_report_affiliate_activity'] = $this->language->get('text_report_affiliate_activity');
+		$this->data['text_report_affiliate'] = $this->language->get('text_report_affiliate');
+		$this->data['text_report_affiliate_activity'] = $this->language->get('text_report_affiliate_activity');
 		$this->data['text_report_affiliate_commission'] = $this->language->get('text_report_affiliate_commission');
 		$this->data['text_report_sale_return'] = $this->language->get('text_report_sale_return');
 		$this->data['text_report_product_viewed'] = $this->language->get('text_report_product_viewed');
@@ -217,7 +218,7 @@ class ControllerCommonHeader extends Controller {
 			$this->data['logged'] = sprintf($this->language->get('text_logged'), $this->user->getUserName());
 
 			$this->data['affiliate'] = $this->url->link('sale/affiliate', 'token=' . $this->session->data['token'], 'SSL');
-//disconnected			$this->data['affiliate'] = $this->url->link('marketing/affiliate', 'token=' . $this->session->data['token'], 'SSL');
+			$this->data['affiliate'] = $this->url->link('marketing/affiliate', 'token=' . $this->session->data['token'], 'SSL');
 			$this->data['api_key_manager'] = $this->url->link('tool/api_key_manager', 'token=' . $this->session->data['token'], 'SSL');
 			$this->data['attribute'] = $this->url->link('catalog/attribute', 'token=' . $this->session->data['token'], 'SSL');
 			$this->data['attribute_group'] = $this->url->link('catalog/attribute_group', 'token=' . $this->session->data['token'], 'SSL');
@@ -230,10 +231,10 @@ class ControllerCommonHeader extends Controller {
 			$this->data['configuration'] = $this->url->link('tool/configuration', 'token=' . $this->session->data['token'], 'SSL');
 			$this->data['connection'] = $this->url->link('design/connection', 'token=' . $this->session->data['token'], 'SSL');
 			$this->data['contact'] = $this->url->link('sale/contact', 'token=' . $this->session->data['token'], 'SSL');
-//disconnected			$this->data['contact'] = $this->url->link('marketing/contact', 'token=' . $this->session->data['token'], 'SSL');
+			$this->data['contact'] = $this->url->link('marketing/contact', 'token=' . $this->session->data['token'], 'SSL');
 			$this->data['country'] = $this->url->link('localisation/country', 'token=' . $this->session->data['token'], 'SSL');
 			$this->data['coupon'] = $this->url->link('sale/coupon', 'token=' . $this->session->data['token'], 'SSL');
-//disconnected			$this->data['coupon'] = $this->url->link('marketing/coupon', 'token=' . $this->session->data['token'], 'SSL');
+			$this->data['coupon'] = $this->url->link('marketing/coupon', 'token=' . $this->session->data['token'], 'SSL');
 			$this->data['currency'] = $this->url->link('localisation/currency', 'token=' . $this->session->data['token'], 'SSL');
 			$this->data['customer'] = $this->url->link('sale/customer', 'token=' . $this->session->data['token'], 'SSL');
 			$this->data['customer_group'] = $this->url->link('sale/customer_group', 'token=' . $this->session->data['token'], 'SSL');
@@ -293,8 +294,8 @@ class ControllerCommonHeader extends Controller {
 			$this->data['report_customer_country'] = $this->url->link('report/customer_country', 'token=' . $this->session->data['token'], 'SSL');
 			$this->data['report_customer_online'] = $this->url->link('report/customer_online', 'token=' . $this->session->data['token'], 'SSL');
 			$this->data['report_marketing'] = $this->url->link('report/marketing', 'token=' . $this->session->data['token'], 'SSL');
-//disconnected			$this->data['report_affiliate'] = $this->url->link('report/affiliate', 'token=' . $this->session->data['token'], 'SSL');
-//disconnected			$this->data['report_affiliate_activity'] = $this->url->link('report/affiliate_activity', 'token=' . $this->session->data['token'], 'SSL');
+			$this->data['report_affiliate'] = $this->url->link('report/affiliate', 'token=' . $this->session->data['token'], 'SSL');
+			$this->data['report_affiliate_activity'] = $this->url->link('report/affiliate_activity', 'token=' . $this->session->data['token'], 'SSL');
 			$this->data['report_affiliate_commission'] = $this->url->link('report/affiliate_commission', 'token=' . $this->session->data['token'], 'SSL');
 			$this->data['review'] = $this->url->link('catalog/review', 'token=' . $this->session->data['token'], 'SSL');
 			$this->data['return'] = $this->url->link('sale/return', 'token=' . $this->session->data['token'], 'SSL');

--- a/upload/admin/controller/common/header.php
+++ b/upload/admin/controller/common/header.php
@@ -259,6 +259,7 @@ class ControllerCommonHeader extends Controller {
 			$this->data['location'] = $this->url->link('localisation/location', 'token=' . $this->session->data['token'], 'SSL');
 			$this->data['logout'] = $this->url->link('common/logout', 'token=' . $this->session->data['token'], 'SSL');
 			$this->data['manufacturer'] = $this->url->link('catalog/manufacturer', 'token=' . $this->session->data['token'], 'SSL');
+			$this->data['marketing'] = $this->url->link('marketing/marketing', 'token=' . $this->session->data['token'], 'SSL');
 			$this->data['menu_manager'] = $this->url->link('design/menu', 'token=' . $this->session->data['token'], 'SSL');
 			$this->data['modification'] = $this->url->link('extension/modification', 'token=' . $this->session->data['token'], 'SSL');
 			$this->data['module'] = $this->url->link('extension/module', 'token=' . $this->session->data['token'], 'SSL');

--- a/upload/admin/controller/localisation/country.php
+++ b/upload/admin/controller/localisation/country.php
@@ -113,7 +113,7 @@ class ControllerLocalisationCountry extends Controller {
 
 		if (isset($this->request->post['selected']) && $this->validate()) {
 			foreach ($this->request->post['selected'] as $country_id) {
-			  	$country_info = $this->model_localisation_country->getCountry($country_id);
+					$country_info = $this->model_localisation_country->getCountry($country_id);
 
 				if ($country_info && !$country_info['status']) {
 					$this->model_localisation_country->enableCountry($country_id);
@@ -155,7 +155,7 @@ class ControllerLocalisationCountry extends Controller {
 
 		if (isset($this->request->post['selected']) && $this->validate()) {
 			foreach ($this->request->post['selected'] as $country_id) {
-			  	$country_info = $this->model_localisation_country->getCountry($country_id);
+					$country_info = $this->model_localisation_country->getCountry($country_id);
 
 				if ($country_info && $country_info['status']) {
 					$this->model_localisation_country->disableCountry($country_id);
@@ -202,7 +202,7 @@ class ControllerLocalisationCountry extends Controller {
 
 			$this->session->data['success'] = $this->language->get('text_success');
 
-			$url = ''; 
+			$url = '';
 
 			if (isset($this->request->get['filter_name'])) {
 				$url .= '&filter_name=' . urlencode(html_entity_decode($this->request->get['filter_name'], ENT_QUOTES, 'UTF-8'));
@@ -631,6 +631,32 @@ class ControllerLocalisationCountry extends Controller {
 		} else {
 			return false;
 		}
+	}
+
+	public function country() {
+		$json = array();
+
+		$this->load->model('localisation/country');
+
+		$country_info = $this->model_localisation_country->getCountry($this->request->get['country_id']);
+
+		if ($country_info) {
+			$this->load->model('localisation/zone');
+
+			$json = array(
+				'country_id'        => $country_info['country_id'],
+				'name'              => $country_info['name'],
+				'iso_code_2'        => $country_info['iso_code_2'],
+				'iso_code_3'        => $country_info['iso_code_3'],
+				'address_format'    => $country_info['address_format'],
+				'postcode_required' => $country_info['postcode_required'],
+				'zone'              => $this->model_localisation_zone->getZonesByCountryId($this->request->get['country_id']),
+				'status'            => $country_info['status']
+			);
+		}
+
+		$this->response->addHeader('Content-Type: application/json');
+		$this->response->setOutput(json_encode($json));
 	}
 
 	public function autocomplete() {

--- a/upload/admin/controller/marketing/affiliate.php
+++ b/upload/admin/controller/marketing/affiliate.php
@@ -1,0 +1,1324 @@
+<?php
+class ControllerMarketingAffiliate extends Controller {
+	private $error = array();
+
+	public function index() {
+		$this->language->load('marketing/affiliate');
+
+		$this->document->setTitle($this->language->get('heading_title'));
+
+		$this->load->model('marketing/affiliate');
+
+		$this->getList();
+	}
+
+	public function insert() {
+		$this->language->load('marketing/affiliate');
+
+		$this->document->setTitle($this->language->get('heading_title'));
+
+		$this->load->model('marketing/affiliate');
+
+		if (($this->request->server['REQUEST_METHOD'] == 'POST') && $this->validateForm()) {
+			$new_affiliate_id = $this->model_marketing_affiliate->addAffiliate($this->request->post);
+
+			$this->session->data['success'] = $this->language->get('text_success');
+
+			$url = '';
+
+			if (isset($this->request->get['filter_name'])) {
+				$url .= '&filter_name=' . urlencode(html_entity_decode($this->request->get['filter_name'], ENT_QUOTES, 'UTF-8'));
+			}
+
+			if (isset($this->request->get['filter_email'])) {
+				$url .= '&filter_email=' . urlencode(html_entity_decode($this->request->get['filter_email'], ENT_QUOTES, 'UTF-8'));
+			}
+
+			if (isset($this->request->get['filter_approved'])) {
+				$url .= '&filter_approved=' . $this->request->get['filter_approved'];
+			}
+
+			if (isset($this->request->get['filter_date_added'])) {
+				$url .= '&filter_date_added=' . $this->request->get['filter_date_added'];
+			}
+
+			if (isset($this->request->get['filter_status'])) {
+				$url .= '&filter_status=' . $this->request->get['filter_status'];
+			}
+
+			if (isset($this->request->get['sort'])) {
+				$url .= '&sort=' . $this->request->get['sort'];
+			}
+
+			if (isset($this->request->get['order'])) {
+				$url .= '&order=' . $this->request->get['order'];
+			}
+
+			if (isset($this->request->get['page'])) {
+				$url .= '&page=' . $this->request->get['page'];
+			}
+
+			if (isset($this->request->post['apply'])) {
+
+				if ($new_affiliate_id) {
+					$this->redirect($this->url->link('marketing/affiliate/update', 'token=' . $this->session->data['token'] . '&affiliate_id=' . $new_affiliate_id . $url, 'SSL'));
+				}
+
+			} else {
+				$this->redirect($this->url->link('marketing/affiliate', 'token=' . $this->session->data['token'] . $url, 'SSL'));
+			}
+		}
+
+		$this->getForm();
+	}
+
+	public function update() {
+		$this->language->load('marketing/affiliate');
+
+		$this->document->setTitle($this->language->get('heading_title'));
+
+		$this->load->model('marketing/affiliate');
+
+		if (($this->request->server['REQUEST_METHOD'] == 'POST') && $this->validateForm()) {
+			$this->model_marketing_affiliate->editAffiliate($this->request->get['affiliate_id'], $this->request->post);
+
+			$this->session->data['success'] = $this->language->get('text_success');
+
+			$url = '';
+
+			if (isset($this->request->get['filter_name'])) {
+				$url .= '&filter_name=' . urlencode(html_entity_decode($this->request->get['filter_name'], ENT_QUOTES, 'UTF-8'));
+			}
+
+			if (isset($this->request->get['filter_email'])) {
+				$url .= '&filter_email=' . urlencode(html_entity_decode($this->request->get['filter_email'], ENT_QUOTES, 'UTF-8'));
+			}
+
+			if (isset($this->request->get['filter_approved'])) {
+				$url .= '&filter_approved=' . $this->request->get['filter_approved'];
+			}
+
+			if (isset($this->request->get['filter_date_added'])) {
+				$url .= '&filter_date_added=' . $this->request->get['filter_date_added'];
+			}
+
+			if (isset($this->request->get['filter_status'])) {
+				$url .= '&filter_status=' . $this->request->get['filter_status'];
+			}
+
+			if (isset($this->request->get['sort'])) {
+				$url .= '&sort=' . $this->request->get['sort'];
+			}
+
+			if (isset($this->request->get['order'])) {
+				$url .= '&order=' . $this->request->get['order'];
+			}
+
+			if (isset($this->request->get['page'])) {
+				$url .= '&page=' . $this->request->get['page'];
+			}
+
+			if (isset($this->request->post['apply'])) {
+				$affiliate_id = $this->request->get['affiliate_id'];
+
+				if ($affiliate_id) {
+					$this->redirect($this->url->link('marketing/affiliate/update', 'token=' . $this->session->data['token'] . '&affiliate_id=' . $affiliate_id . $url, 'SSL'));
+				}
+
+			} else {
+				$this->redirect($this->url->link('marketing/affiliate', 'token=' . $this->session->data['token'] . $url, 'SSL'));
+			}
+		}
+
+		$this->getForm();
+	}
+
+	public function delete() {
+		$this->language->load('marketing/affiliate');
+
+		$this->document->setTitle($this->language->get('heading_title'));
+
+		$this->load->model('marketing/affiliate');
+
+		if (isset($this->request->post['selected']) && $this->validateDelete()) {
+			foreach ($this->request->post['selected'] as $affiliate_id) {
+				$this->model_marketing_affiliate->deleteAffiliate($affiliate_id);
+			}
+
+			$this->session->data['success'] = $this->language->get('text_success');
+
+			$url = '';
+
+			if (isset($this->request->get['filter_name'])) {
+				$url .= '&filter_name=' . urlencode(html_entity_decode($this->request->get['filter_name'], ENT_QUOTES, 'UTF-8'));
+			}
+
+			if (isset($this->request->get['filter_email'])) {
+				$url .= '&filter_email=' . urlencode(html_entity_decode($this->request->get['filter_email'], ENT_QUOTES, 'UTF-8'));
+			}
+
+			if (isset($this->request->get['filter_approved'])) {
+				$url .= '&filter_approved=' . $this->request->get['filter_approved'];
+			}
+
+			if (isset($this->request->get['filter_date_added'])) {
+				$url .= '&filter_date_added=' . $this->request->get['filter_date_added'];
+			}
+
+			if (isset($this->request->get['filter_status'])) {
+				$url .= '&filter_status=' . $this->request->get['filter_status'];
+			}
+
+			if (isset($this->request->get['sort'])) {
+				$url .= '&sort=' . $this->request->get['sort'];
+			}
+
+			if (isset($this->request->get['order'])) {
+				$url .= '&order=' . $this->request->get['order'];
+			}
+
+			if (isset($this->request->get['page'])) {
+				$url .= '&page=' . $this->request->get['page'];
+			}
+
+			$this->redirect($this->url->link('marketing/affiliate', 'token=' . $this->session->data['token'] . $url, 'SSL'));
+		}
+
+		$this->getList();
+	}
+
+	public function approve() {
+		$this->language->load('marketing/affiliate');
+
+		$this->document->setTitle($this->language->get('heading_title'));
+
+		$this->load->model('marketing/affiliate');
+
+		if (isset($this->request->post['selected']) && $this->validateApprove()) {
+			$approved = 0;
+
+			foreach ($this->request->post['selected'] as $affiliate_id) {
+				$affiliate_info = $this->model_marketing_affiliate->getAffiliate($affiliate_id);
+
+				if ($affiliate_info && !$affiliate_info['approved']) {
+					$this->model_marketing_affiliate->approve($affiliate_id);
+
+					$approved++;
+				}
+			}
+
+			$this->session->data['success'] = sprintf($this->language->get('text_approved'), $approved);
+
+			$url = '';
+
+			if (isset($this->request->get['filter_name'])) {
+				$url .= '&filter_name=' . urlencode(html_entity_decode($this->request->get['filter_name'], ENT_QUOTES, 'UTF-8'));
+			}
+
+			if (isset($this->request->get['filter_email'])) {
+				$url .= '&filter_email=' . urlencode(html_entity_decode($this->request->get['filter_email'], ENT_QUOTES, 'UTF-8'));
+			}
+
+			if (isset($this->request->get['filter_approved'])) {
+				$url .= '&filter_approved=' . $this->request->get['filter_approved'];
+			}
+
+			if (isset($this->request->get['filter_date_added'])) {
+				$url .= '&filter_date_added=' . $this->request->get['filter_date_added'];
+			}
+
+			if (isset($this->request->get['filter_status'])) {
+				$url .= '&filter_status=' . $this->request->get['filter_status'];
+			}
+
+			if (isset($this->request->get['sort'])) {
+				$url .= '&sort=' . $this->request->get['sort'];
+			}
+
+			if (isset($this->request->get['order'])) {
+				$url .= '&order=' . $this->request->get['order'];
+			}
+
+			if (isset($this->request->get['page'])) {
+				$url .= '&page=' . $this->request->get['page'];
+			}
+
+			$this->redirect($this->url->link('marketing/affiliate', 'token=' . $this->session->data['token'] . $url, 'SSL'));
+		}
+
+		$this->getList();
+	}
+
+	public function unlock() {
+		$this->load->language('marketing/affiliate');
+
+		$this->document->setTitle($this->language->get('heading_title'));
+
+		$this->load->model('marketing/affiliate');
+
+		if (isset($this->request->post['selected']) && $this->validateUnlock()) {
+			$this->model_marketing_affiliate->deleteLoginAttempts($this->request->get['email']);
+
+			$this->session->data['success'] = $this->language->get('text_success');
+
+			$url = '';
+
+			if (isset($this->request->get['filter_name'])) {
+				$url .= '&filter_name=' . urlencode(html_entity_decode($this->request->get['filter_name'], ENT_QUOTES, 'UTF-8'));
+			}
+
+			if (isset($this->request->get['filter_email'])) {
+				$url .= '&filter_email=' . urlencode(html_entity_decode($this->request->get['filter_email'], ENT_QUOTES, 'UTF-8'));
+			}
+
+			if (isset($this->request->get['filter_status'])) {
+				$url .= '&filter_status=' . $this->request->get['filter_status'];
+			}
+
+			if (isset($this->request->get['filter_approved'])) {
+				$url .= '&filter_approved=' . $this->request->get['filter_approved'];
+			}
+
+			if (isset($this->request->get['filter_date_added'])) {
+				$url .= '&filter_date_added=' . $this->request->get['filter_date_added'];
+			}
+
+			if (isset($this->request->get['sort'])) {
+				$url .= '&sort=' . $this->request->get['sort'];
+			}
+
+			if (isset($this->request->get['order'])) {
+				$url .= '&order=' . $this->request->get['order'];
+			}
+
+			if (isset($this->request->get['page'])) {
+				$url .= '&page=' . $this->request->get['page'];
+			}
+
+			$this->response->redirect($this->url->link('marketing/affiliate', 'token=' . $this->session->data['token'] . $url, true));
+		}
+
+		$this->getList();
+	}
+
+	protected function getList() {
+		if (isset($this->request->get['filter_name'])) {
+			$filter_name = $this->request->get['filter_name'];
+		} else {
+			$filter_name = null;
+		}
+
+		if (isset($this->request->get['filter_email'])) {
+			$filter_email = $this->request->get['filter_email'];
+		} else {
+			$filter_email = null;
+		}
+
+		if (isset($this->request->get['filter_approved'])) {
+			$filter_approved = $this->request->get['filter_approved'];
+		} else {
+			$filter_approved = null;
+		}
+
+		if (isset($this->request->get['filter_date_added'])) {
+			$filter_date_added = $this->request->get['filter_date_added'];
+		} else {
+			$filter_date_added = null;
+		}
+
+		if (isset($this->request->get['filter_status'])) {
+			$filter_status = $this->request->get['filter_status'];
+		} else {
+			$filter_status = null;
+		}
+
+		if (isset($this->request->get['sort'])) {
+			$sort = $this->request->get['sort'];
+		} else {
+			$sort = 'name';
+		}
+
+		if (isset($this->request->get['order'])) {
+			$order = $this->request->get['order'];
+		} else {
+			$order = 'ASC';
+		}
+
+		if (isset($this->request->get['page'])) {
+			$page = $this->request->get['page'];
+		} else {
+			$page = 1;
+		}
+
+		$url = '';
+
+		if (isset($this->request->get['filter_name'])) {
+			$url .= '&filter_name=' . urlencode(html_entity_decode($this->request->get['filter_name'], ENT_QUOTES, 'UTF-8'));
+		}
+
+		if (isset($this->request->get['filter_email'])) {
+			$url .= '&filter_email=' . urlencode(html_entity_decode($this->request->get['filter_email'], ENT_QUOTES, 'UTF-8'));
+		}
+
+		if (isset($this->request->get['filter_approved'])) {
+			$url .= '&filter_approved=' . $this->request->get['filter_approved'];
+		}
+
+		if (isset($this->request->get['filter_date_added'])) {
+			$url .= '&filter_date_added=' . $this->request->get['filter_date_added'];
+		}
+
+		if (isset($this->request->get['filter_status'])) {
+			$url .= '&filter_status=' . $this->request->get['filter_status'];
+		}
+
+		if (isset($this->request->get['sort'])) {
+			$url .= '&sort=' . $this->request->get['sort'];
+		}
+
+		if (isset($this->request->get['order'])) {
+			$url .= '&order=' . $this->request->get['order'];
+		}
+
+		if (isset($this->request->get['page'])) {
+			$url .= '&page=' . $this->request->get['page'];
+		}
+
+		$this->data['breadcrumbs'] = array();
+
+		$this->data['breadcrumbs'][] = array(
+			'text' => $this->language->get('text_home'),
+			'href' => $this->url->link('common/home', 'token=' . $this->session->data['token'], 'SSL'),
+			'separator' => false
+		);
+
+		$this->data['breadcrumbs'][] = array(
+			'text' => $this->language->get('heading_title'),
+			'href' => $this->url->link('marketing/affiliate', 'token=' . $this->session->data['token'] . $url, 'SSL'),
+			'separator' => ' :: '
+		);
+
+		$this->data['approve'] = $this->url->link('marketing/affiliate/approve', 'token=' . $this->session->data['token'] . $url, 'SSL');
+		$this->data['insert'] = $this->url->link('marketing/affiliate/insert', 'token=' . $this->session->data['token'] . $url, 'SSL');
+		$this->data['delete'] = $this->url->link('marketing/affiliate/delete', 'token=' . $this->session->data['token'] . $url, 'SSL');
+
+		// Pagination
+		$this->data['navigation_hi'] = $this->config->get('config_pagination_hi');
+		$this->data['navigation_lo'] = $this->config->get('config_pagination_lo');
+
+		$this->data['affiliates'] = array();
+
+		$filter_data = array(
+			'filter_name'       => $filter_name,
+			'filter_email'      => $filter_email,
+			'filter_status'     => $filter_status,
+			'filter_approved'   => $filter_approved,
+			'filter_date_added' => $filter_date_added,
+			'sort'              => $sort,
+			'order'             => $order,
+			'start'             => ($page - 1) * $this->config->get('config_admin_limit'),
+			'limit'             => $this->config->get('config_admin_limit')
+		);
+
+		$affiliate_total = $this->model_marketing_affiliate->getTotalAffiliates($filter_data);
+
+		$results = $this->model_marketing_affiliate->getAffiliates($filter_data);
+
+		foreach ($results as $result) {
+			$action = array();
+
+			if ($this->config->has('config_login_attempts')) {
+				$login_info = $this->model_marketing_affiliate->getTotalLoginAttempts($result['email']);
+
+				if ($login_info && ($login_info['total'] >= $this->config->get('config_login_attempts'))) {
+					$action[] = array(
+						'text' => $this->language->get('text_unlock'),
+						'href' => $this->url->link('marketing/affiliate/unlock', 'token=' . $this->session->data['token'] . '&email=' . $result['email'] . $url, 'SSL')
+					);
+				}
+			}
+
+			$action[] = array(
+				'text' => $this->language->get('text_edit'),
+				'href' => $this->url->link('marketing/affiliate/update', 'token=' . $this->session->data['token'] . '&affiliate_id=' . $result['affiliate_id'] . $url, 'SSL')
+			);
+
+			$this->data['affiliates'][] = array(
+				'affiliate_id' => $result['affiliate_id'],
+				'name'         => $result['name'],
+				'email'        => $result['email'],
+				'balance'      => $this->currency->format($result['balance'], $this->config->get('config_currency')),
+				'approved'     => $result['approved'] ? $this->language->get('text_yes') : $this->language->get('text_no'),
+				'date_added'   => date($this->language->get('date_format_short'), strtotime($result['date_added'])),
+				'status'       => $result['status'],
+				'selected'     => isset($this->request->post['selected']) && in_array($result['affiliate_id'], $this->request->post['selected']),
+				'action'       => $action
+			);
+		}
+
+		$this->data['heading_title'] = $this->language->get('heading_title');
+
+		$this->data['text_no_results'] = $this->language->get('text_no_results');
+		$this->data['text_enabled'] = $this->language->get('text_enabled');
+		$this->data['text_disabled'] = $this->language->get('text_disabled');
+		$this->data['text_yes'] = $this->language->get('text_yes');
+		$this->data['text_no'] = $this->language->get('text_no');
+		$this->data['text_unlock'] = $this->language->get('text_unlock');
+
+		$this->data['column_name'] = $this->language->get('column_name');
+		$this->data['column_email'] = $this->language->get('column_email');
+		$this->data['column_balance'] = $this->language->get('column_balance');
+		$this->data['column_approved'] = $this->language->get('column_approved');
+		$this->data['column_date_added'] = $this->language->get('column_date_added');
+		$this->data['column_status'] = $this->language->get('column_status');
+		$this->data['column_action'] = $this->language->get('column_action');
+
+		$this->data['button_approve'] = $this->language->get('button_approve');
+		$this->data['button_insert'] = $this->language->get('button_insert');
+		$this->data['button_delete'] = $this->language->get('button_delete');
+		$this->data['button_filter'] = $this->language->get('button_filter');
+
+		$this->data['token'] = $this->session->data['token'];
+
+		if (isset($this->error['warning'])) {
+			$this->data['error_warning'] = $this->error['warning'];
+		} else {
+			$this->data['error_warning'] = '';
+		}
+
+		if (isset($this->session->data['success'])) {
+			$this->data['success'] = $this->session->data['success'];
+
+			unset($this->session->data['success']);
+		} else {
+			$this->data['success'] = '';
+		}
+
+		if (isset($this->request->post['selected'])) {
+			$this->data['selected'] = (array)$this->request->post['selected'];
+		} else {
+			$this->data['selected'] = array();
+		}
+
+		$url = '';
+
+		if (isset($this->request->get['filter_name'])) {
+			$url .= '&filter_name=' . urlencode(html_entity_decode($this->request->get['filter_name'], ENT_QUOTES, 'UTF-8'));
+		}
+
+		if (isset($this->request->get['filter_email'])) {
+			$url .= '&filter_email=' . urlencode(html_entity_decode($this->request->get['filter_email'], ENT_QUOTES, 'UTF-8'));
+		}
+
+		if (isset($this->request->get['filter_approved'])) {
+			$url .= '&filter_approved=' . $this->request->get['filter_approved'];
+		}
+
+		if (isset($this->request->get['filter_date_added'])) {
+			$url .= '&filter_date_added=' . $this->request->get['filter_date_added'];
+		}
+
+		if (isset($this->request->get['filter_status'])) {
+			$url .= '&filter_status=' . $this->request->get['filter_status'];
+		}
+
+		if ($order == 'ASC') {
+			$url .= '&order=DESC';
+		} else {
+			$url .= '&order=ASC';
+		}
+
+		if (isset($this->request->get['page'])) {
+			$url .= '&page=' . $this->request->get['page'];
+		}
+
+		$this->data['sort_name'] = $this->url->link('marketing/affiliate', 'token=' . $this->session->data['token'] . '&sort=name' . $url, 'SSL');
+		$this->data['sort_email'] = $this->url->link('marketing/affiliate', 'token=' . $this->session->data['token'] . '&sort=a.email' . $url, 'SSL');
+		$this->data['sort_approved'] = $this->url->link('marketing/affiliate', 'token=' . $this->session->data['token'] . '&sort=a.approved' . $url, 'SSL');
+		$this->data['sort_date_added'] = $this->url->link('marketing/affiliate', 'token=' . $this->session->data['token'] . '&sort=a.date_added' . $url, 'SSL');
+		$this->data['sort_status'] = $this->url->link('marketing/affiliate', 'token=' . $this->session->data['token'] . '&sort=a.status' . $url, 'SSL');
+
+		$url = '';
+
+		if (isset($this->request->get['filter_name'])) {
+			$url .= '&filter_name=' . urlencode(html_entity_decode($this->request->get['filter_name'], ENT_QUOTES, 'UTF-8'));
+		}
+
+		if (isset($this->request->get['filter_email'])) {
+			$url .= '&filter_email=' . urlencode(html_entity_decode($this->request->get['filter_email'], ENT_QUOTES, 'UTF-8'));
+		}
+
+		if (isset($this->request->get['filter_approved'])) {
+			$url .= '&filter_approved=' . $this->request->get['filter_approved'];
+		}
+
+		if (isset($this->request->get['filter_date_added'])) {
+			$url .= '&filter_date_added=' . $this->request->get['filter_date_added'];
+		}
+
+		if (isset($this->request->get['filter_status'])) {
+			$url .= '&filter_status=' . $this->request->get['filter_status'];
+		}
+
+		if (isset($this->request->get['sort'])) {
+			$url .= '&sort=' . $this->request->get['sort'];
+		}
+
+		if (isset($this->request->get['order'])) {
+			$url .= '&order=' . $this->request->get['order'];
+		}
+
+		$pagination = new Pagination();
+		$pagination->total = $affiliate_total;
+		$pagination->page = $page;
+		$pagination->limit = $this->config->get('config_admin_limit');
+		$pagination->text = $this->language->get('text_pagination');
+		$pagination->url = $this->url->link('marketing/affiliate', 'token=' . $this->session->data['token'] . $url . '&page={page}', 'SSL');
+
+		$this->data['pagination'] = $pagination->render();
+
+		$this->data['filter_name'] = $filter_name;
+		$this->data['filter_email'] = $filter_email;
+		$this->data['filter_approved'] = $filter_approved;
+		$this->data['filter_date_added'] = $filter_date_added;
+		$this->data['filter_status'] = $filter_status;
+
+		$this->data['sort'] = $sort;
+		$this->data['order'] = $order;
+
+		$this->template = 'marketing/affiliate_list.tpl';
+		$this->children = array(
+			'common/header',
+			'common/footer'
+		);
+
+		$this->response->setOutput($this->render());
+	}
+
+	protected function getForm() {
+		$this->data['heading_title'] = $this->language->get('heading_title');
+
+		$this->data['text_affiliate_detail'] = $this->language->get('text_affiliate_detail');
+		$this->data['text_affiliate_address'] = $this->language->get('text_affiliate_address');
+		$this->data['text_enabled'] = $this->language->get('text_enabled');
+		$this->data['text_disabled'] = $this->language->get('text_disabled');
+		$this->data['text_select'] = $this->language->get('text_select');
+		$this->data['text_none'] = $this->language->get('text_none');
+		$this->data['text_wait'] = $this->language->get('text_wait');
+		$this->data['text_cheque'] = $this->language->get('text_cheque');
+		$this->data['text_paypal'] = $this->language->get('text_paypal');
+		$this->data['text_bank'] = $this->language->get('text_bank');
+
+		$this->data['entry_firstname'] = $this->language->get('entry_firstname');
+		$this->data['entry_lastname'] = $this->language->get('entry_lastname');
+		$this->data['entry_email'] = $this->language->get('entry_email');
+		$this->data['entry_telephone'] = $this->language->get('entry_telephone');
+		$this->data['entry_fax'] = $this->language->get('entry_fax');
+		$this->data['entry_company'] = $this->language->get('entry_company');
+		$this->data['entry_website'] = $this->language->get('entry_website');
+		$this->data['entry_address_1'] = $this->language->get('entry_address_1');
+		$this->data['entry_address_2'] = $this->language->get('entry_address_2');
+		$this->data['entry_city'] = $this->language->get('entry_city');
+		$this->data['entry_postcode'] = $this->language->get('entry_postcode');
+		$this->data['entry_country'] = $this->language->get('entry_country');
+		$this->data['entry_zone'] = $this->language->get('entry_zone');
+		$this->data['entry_code'] = $this->language->get('entry_code');
+		$this->data['entry_commission'] = $this->language->get('entry_commission');
+		$this->data['entry_tax'] = $this->language->get('entry_tax');
+		$this->data['entry_payment'] = $this->language->get('entry_payment');
+		$this->data['entry_cheque'] = $this->language->get('entry_cheque');
+		$this->data['entry_paypal'] = $this->language->get('entry_paypal');
+		$this->data['entry_bank_name'] = $this->language->get('entry_bank_name');
+		$this->data['entry_bank_branch_number'] = $this->language->get('entry_bank_branch_number');
+		$this->data['entry_bank_swift_code'] = $this->language->get('entry_bank_swift_code');
+		$this->data['entry_bank_account_name'] = $this->language->get('entry_bank_account_name');
+		$this->data['entry_bank_account_number'] = $this->language->get('entry_bank_account_number');
+		$this->data['entry_password'] = $this->language->get('entry_password');
+		$this->data['entry_confirm'] = $this->language->get('entry_confirm');
+		$this->data['entry_status'] = $this->language->get('entry_status');
+		$this->data['entry_amount'] = $this->language->get('entry_amount');
+		$this->data['entry_description'] = $this->language->get('entry_description');
+
+		$this->data['help_code'] = $this->language->get('help_code');
+		$this->data['help_commission'] = $this->language->get('help_commission');
+		$this->data['help_amount'] = $this->language->get('help_amount');
+
+		$this->data['button_save'] = $this->language->get('button_save');
+		$this->data['button_apply'] = $this->language->get('button_apply');
+		$this->data['button_cancel'] = $this->language->get('button_cancel');
+		$this->data['button_add_transaction'] = $this->language->get('button_add_transaction');
+		$this->data['button_remove'] = $this->language->get('button_remove');
+
+		$this->data['tab_general'] = $this->language->get('tab_general');
+		$this->data['tab_payment'] = $this->language->get('tab_payment');
+		$this->data['tab_transaction'] = $this->language->get('tab_transaction');
+
+		$this->data['token'] = $this->session->data['token'];
+
+		if (isset($this->error['warning'])) {
+			$this->data['error_warning'] = $this->error['warning'];
+		} else {
+			$this->data['error_warning'] = '';
+		}
+
+		if (isset($this->session->data['success'])) {
+			$this->data['success'] = $this->session->data['success'];
+
+			unset($this->session->data['success']);
+		} else {
+			$this->data['success'] = '';
+		}
+
+		if (isset($this->error['firstname'])) {
+			$this->data['error_firstname'] = $this->error['firstname'];
+		} else {
+			$this->data['error_firstname'] = '';
+		}
+
+		if (isset($this->error['lastname'])) {
+			$this->data['error_lastname'] = $this->error['lastname'];
+		} else {
+			$this->data['error_lastname'] = '';
+		}
+
+		if (isset($this->error['email'])) {
+			$this->data['error_email'] = $this->error['email'];
+		} else {
+			$this->data['error_email'] = '';
+		}
+
+		if (isset($this->error['cheque'])) {
+			$this->data['error_cheque'] = $this->error['cheque'];
+		} else {
+			$this->data['error_cheque'] = '';
+		}
+
+		if (isset($this->error['paypal'])) {
+			$this->data['error_paypal'] = $this->error['paypal'];
+		} else {
+			$this->data['error_paypal'] = '';
+		}
+
+		if (isset($this->error['bank_account_name'])) {
+			$this->data['error_bank_account_name'] = $this->error['bank_account_name'];
+		} else {
+			$this->data['error_bank_account_name'] = '';
+		}
+
+		if (isset($this->error['bank_account_number'])) {
+			$this->data['error_bank_account_number'] = $this->error['bank_account_number'];
+		} else {
+			$this->data['error_bank_account_number'] = '';
+		}
+
+		if (isset($this->error['telephone'])) {
+			$this->data['error_telephone'] = $this->error['telephone'];
+		} else {
+			$this->data['error_telephone'] = '';
+		}
+
+		if (isset($this->error['password'])) {
+			$this->data['error_password'] = $this->error['password'];
+		} else {
+			$this->data['error_password'] = '';
+		}
+
+		if (isset($this->error['confirm'])) {
+			$this->data['error_confirm'] = $this->error['confirm'];
+		} else {
+			$this->data['error_confirm'] = '';
+		}
+
+		if (isset($this->error['address_1'])) {
+			$this->data['error_address_1'] = $this->error['address_1'];
+		} else {
+			$this->data['error_address_1'] = '';
+		}
+
+		if (isset($this->error['city'])) {
+			$this->data['error_city'] = $this->error['city'];
+		} else {
+			$this->data['error_city'] = '';
+		}
+
+		if (isset($this->error['postcode'])) {
+			$this->data['error_postcode'] = $this->error['postcode'];
+		} else {
+			$this->data['error_postcode'] = '';
+		}
+
+		if (isset($this->error['country'])) {
+			$this->data['error_country'] = $this->error['country'];
+		} else {
+			$this->data['error_country'] = '';
+		}
+
+		if (isset($this->error['zone'])) {
+			$this->data['error_zone'] = $this->error['zone'];
+		} else {
+			$this->data['error_zone'] = '';
+		}
+
+		if (isset($this->error['code'])) {
+			$this->data['error_code'] = $this->error['code'];
+		} else {
+			$this->data['error_code'] = '';
+		}
+
+		$url = '';
+
+		if (isset($this->request->get['filter_name'])) {
+			$url .= '&filter_name=' . urlencode(html_entity_decode($this->request->get['filter_name'], ENT_QUOTES, 'UTF-8'));
+		}
+
+		if (isset($this->request->get['filter_email'])) {
+			$url .= '&filter_email=' . urlencode(html_entity_decode($this->request->get['filter_email'], ENT_QUOTES, 'UTF-8'));
+		}
+
+		if (isset($this->request->get['filter_approved'])) {
+			$url .= '&filter_approved=' . $this->request->get['filter_approved'];
+		}
+
+		if (isset($this->request->get['filter_date_added'])) {
+			$url .= '&filter_date_added=' . $this->request->get['filter_date_added'];
+		}
+
+		if (isset($this->request->get['filter_status'])) {
+			$url .= '&filter_status=' . $this->request->get['filter_status'];
+		}
+
+		if (isset($this->request->get['sort'])) {
+			$url .= '&sort=' . $this->request->get['sort'];
+		}
+
+		if (isset($this->request->get['order'])) {
+			$url .= '&order=' . $this->request->get['order'];
+		}
+
+		if (isset($this->request->get['page'])) {
+			$url .= '&page=' . $this->request->get['page'];
+		}
+
+		$this->data['breadcrumbs'] = array();
+
+		$this->data['breadcrumbs'][] = array(
+			'text' => $this->language->get('text_home'),
+			'href' => $this->url->link('common/home', 'token=' . $this->session->data['token'], 'SSL'),
+			'separator' => false
+		);
+
+		if (isset($this->request->get['affiliate_id'])) {
+			$affiliate_name = $this->model_marketing_affiliate->getAffiliate($this->request->get['affiliate_id']);
+
+			$this->data['breadcrumbs'][] = array(
+				'text'      => $this->language->get('heading_title') . ' :: ' . $affiliate_name['firstname'] . ' ' . $affiliate_name['lastname'],
+				'href'      => $this->url->link('marketing/affiliate/update', 'token=' . $this->session->data['token'] . '&affiliate_id=' . $this->request->get['affiliate_id'] . $url, 'SSL'),
+				'separator' => ' :: '
+			);
+
+			$this->data['affiliate_title'] = $affiliate_name['firstname'] . ' ' . $affiliate_name['lastname'];
+
+		} else {
+			$this->data['breadcrumbs'][] = array(
+				'text'      => $this->language->get('heading_title'),
+				'href'      => $this->url->link('marketing/affiliate', 'token=' . $this->session->data['token'] . $url, 'SSL'),
+				'separator' => ' :: '
+			);
+
+			$this->data['affiliate_title'] = $this->language->get('heading_title');
+		}
+
+		if (!isset($this->request->get['affiliate_id'])) {
+			$this->data['action'] = $this->url->link('marketing/affiliate/insert', 'token=' . $this->session->data['token'] . $url, 'SSL');
+		} else {
+			$this->data['action'] = $this->url->link('marketing/affiliate/update', 'token=' . $this->session->data['token'] . '&affiliate_id=' . $this->request->get['affiliate_id'] . $url, 'SSL');
+		}
+
+		$this->data['cancel'] = $this->url->link('marketing/affiliate', 'token=' . $this->session->data['token'] . $url, 'SSL');
+
+		if (isset($this->request->get['affiliate_id']) && ($this->request->server['REQUEST_METHOD'] != 'POST')) {
+			$affiliate_info = $this->model_marketing_affiliate->getAffiliate($this->request->get['affiliate_id']);
+		}
+
+		if (isset($this->request->get['affiliate_id'])) {
+			$this->data['affiliate_id'] = $this->request->get['affiliate_id'];
+		} else {
+			$this->data['affiliate_id'] = 0;
+		}
+
+		if (isset($this->request->post['firstname'])) {
+			$this->data['firstname'] = $this->request->post['firstname'];
+		} elseif (!empty($affiliate_info)) {
+			$this->data['firstname'] = $affiliate_info['firstname'];
+		} else {
+			$this->data['firstname'] = '';
+		}
+
+		if (isset($this->request->post['lastname'])) {
+			$this->data['lastname'] = $this->request->post['lastname'];
+		} elseif (!empty($affiliate_info)) {
+			$this->data['lastname'] = $affiliate_info['lastname'];
+		} else {
+			$this->data['lastname'] = '';
+		}
+
+		if (isset($this->request->post['email'])) {
+			$this->data['email'] = $this->request->post['email'];
+		} elseif (!empty($affiliate_info)) {
+			$this->data['email'] = $affiliate_info['email'];
+		} else {
+			$this->data['email'] = '';
+		}
+
+		if (isset($this->request->post['telephone'])) {
+			$this->data['telephone'] = $this->request->post['telephone'];
+		} elseif (!empty($affiliate_info)) {
+			$this->data['telephone'] = $affiliate_info['telephone'];
+		} else {
+			$this->data['telephone'] = '';
+		}
+
+		$this->data['show_fax'] = $this->config->get('config_affiliate_fax');
+
+		if (isset($this->request->post['fax'])) {
+			$this->data['fax'] = $this->request->post['fax'];
+		} elseif (!empty($affiliate_info)) {
+			$this->data['fax'] = $affiliate_info['fax'];
+		} else {
+			$this->data['fax'] = '';
+		}
+
+		if (isset($this->request->post['company'])) {
+			$this->data['company'] = $this->request->post['company'];
+		} elseif (!empty($affiliate_info)) {
+			$this->data['company'] = $affiliate_info['company'];
+		} else {
+			$this->data['company'] = '';
+		}
+
+		if (isset($this->request->post['website'])) {
+			$this->data['website'] = $this->request->post['website'];
+		} elseif (!empty($affiliate_info)) {
+			$this->data['website'] = $affiliate_info['website'];
+		} else {
+			$this->data['website'] = '';
+		}
+
+		if (isset($this->request->post['address_1'])) {
+			$this->data['address_1'] = $this->request->post['address_1'];
+		} elseif (!empty($affiliate_info)) {
+			$this->data['address_1'] = $affiliate_info['address_1'];
+		} else {
+			$this->data['address_1'] = '';
+		}
+
+		if (isset($this->request->post['address_2'])) {
+			$this->data['address_2'] = $this->request->post['address_2'];
+		} elseif (!empty($affiliate_info)) {
+			$this->data['address_2'] = $affiliate_info['address_2'];
+		} else {
+			$this->data['address_2'] = '';
+		}
+
+		if (isset($this->request->post['city'])) {
+			$this->data['city'] = $this->request->post['city'];
+		} elseif (!empty($affiliate_info)) {
+			$this->data['city'] = $affiliate_info['city'];
+		} else {
+			$this->data['city'] = '';
+		}
+
+		if (isset($this->request->post['postcode'])) {
+			$this->data['postcode'] = $this->request->post['postcode'];
+		} elseif (!empty($affiliate_info)) {
+			$this->data['postcode'] = $affiliate_info['postcode'];
+		} else {
+			$this->data['postcode'] = '';
+		}
+
+		if (isset($this->request->post['country_id'])) {
+			$this->data['country_id'] = $this->request->post['country_id'];
+		} elseif (!empty($affiliate_info)) {
+			$this->data['country_id'] = $affiliate_info['country_id'];
+		} else {
+			$this->data['country_id'] = '';
+		}
+
+		$this->load->model('localisation/country');
+
+		$this->data['countries'] = $this->model_localisation_country->getCountries();
+
+		if (isset($this->request->post['zone_id'])) {
+			$this->data['zone_id'] = (int)$this->request->post['zone_id'];
+		} elseif (!empty($affiliate_info)) {
+			$this->data['zone_id'] = $affiliate_info['zone_id'];
+		} else {
+			$this->data['zone_id'] = '';
+		}
+
+		if (isset($this->request->post['code'])) {
+			$this->data['code'] = $this->request->post['code'];
+		} elseif (!empty($affiliate_info)) {
+			$this->data['code'] = $affiliate_info['code'];
+		} else {
+			$this->data['code'] = uniqid();
+		}
+
+		if (isset($this->request->post['commission'])) {
+			$this->data['commission'] = $this->request->post['commission'];
+		} elseif (!empty($affiliate_info)) {
+			$this->data['commission'] = $affiliate_info['commission'];
+		} else {
+//PB Changer config_commission
+			$this->data['commission'] = $this->config->get('config_affiliate_commission');
+		}
+
+		if (isset($this->request->post['tax'])) {
+			$this->data['tax'] = $this->request->post['tax'];
+		} elseif (!empty($affiliate_info)) {
+			$this->data['tax'] = $affiliate_info['tax'];
+		} else {
+			$this->data['tax'] = '';
+		}
+
+		if (isset($this->request->post['payment'])) {
+			$this->data['payment'] = $this->request->post['payment'];
+		} elseif (!empty($affiliate_info)) {
+			$this->data['payment'] = $affiliate_info['payment'];
+		} else {
+			$this->data['payment'] = 'cheque';
+		}
+
+		if (isset($this->request->post['cheque'])) {
+			$this->data['cheque'] = $this->request->post['cheque'];
+		} elseif (!empty($affiliate_info)) {
+			$this->data['cheque'] = $affiliate_info['cheque'];
+		} else {
+			$this->data['cheque'] = '';
+		}
+
+		if (isset($this->request->post['paypal'])) {
+			$this->data['paypal'] = $this->request->post['paypal'];
+		} elseif (!empty($affiliate_info)) {
+			$this->data['paypal'] = $affiliate_info['paypal'];
+		} else {
+			$this->data['paypal'] = '';
+		}
+
+		if (isset($this->request->post['bank_name'])) {
+			$this->data['bank_name'] = $this->request->post['bank_name'];
+		} elseif (!empty($affiliate_info)) {
+			$this->data['bank_name'] = $affiliate_info['bank_name'];
+		} else {
+			$this->data['bank_name'] = '';
+		}
+
+		if (isset($this->request->post['bank_branch_number'])) {
+			$this->data['bank_branch_number'] = $this->request->post['bank_branch_number'];
+		} elseif (!empty($affiliate_info)) {
+			$this->data['bank_branch_number'] = $affiliate_info['bank_branch_number'];
+		} else {
+			$this->data['bank_branch_number'] = '';
+		}
+
+		if (isset($this->request->post['bank_swift_code'])) {
+			$this->data['bank_swift_code'] = $this->request->post['bank_swift_code'];
+		} elseif (!empty($affiliate_info)) {
+			$this->data['bank_swift_code'] = $affiliate_info['bank_swift_code'];
+		} else {
+			$this->data['bank_swift_code'] = '';
+		}
+
+		if (isset($this->request->post['bank_account_name'])) {
+			$this->data['bank_account_name'] = $this->request->post['bank_account_name'];
+		} elseif (!empty($affiliate_info)) {
+			$this->data['bank_account_name'] = $affiliate_info['bank_account_name'];
+		} else {
+			$this->data['bank_account_name'] = '';
+		}
+
+		if (isset($this->request->post['bank_account_number'])) {
+			$this->data['bank_account_number'] = $this->request->post['bank_account_number'];
+		} elseif (!empty($affiliate_info)) {
+			$this->data['bank_account_number'] = $affiliate_info['bank_account_number'];
+		} else {
+			$this->data['bank_account_number'] = '';
+		}
+
+		if (isset($this->request->post['status'])) {
+			$this->data['status'] = $this->request->post['status'];
+		} elseif (!empty($affiliate_info)) {
+			$this->data['status'] = $affiliate_info['status'];
+		} else {
+			$this->data['status'] = true;
+		}
+
+		if (isset($this->request->post['password'])) {
+			$this->data['password'] = $this->request->post['password'];
+		} else {
+			$this->data['password'] = '';
+		}
+
+		if (isset($this->request->post['confirm'])) {
+			$this->data['confirm'] = $this->request->post['confirm'];
+		} else {
+			$this->data['confirm'] = '';
+		}
+
+		$this->template = 'marketing/affiliate_form.tpl';
+		$this->children = array(
+			'common/header',
+			'common/footer'
+		);
+
+		$this->response->setOutput($this->render());
+	}
+
+	protected function validateForm() {
+		if (!$this->user->hasPermission('modify', 'marketing/affiliate')) {
+			$this->error['warning'] = $this->language->get('error_permission');
+		}
+
+		if ((utf8_strlen(trim($this->request->post['firstname'])) < 1) || (utf8_strlen(trim($this->request->post['firstname'])) > 32)) {
+			$this->error['firstname'] = $this->language->get('error_firstname');
+		}
+
+		if ((utf8_strlen(trim($this->request->post['lastname'])) < 1) || (utf8_strlen(trim($this->request->post['lastname'])) > 32)) {
+			$this->error['lastname'] = $this->language->get('error_lastname');
+		}
+
+		if ((utf8_strlen($this->request->post['email']) > 96) || (!filter_var($this->request->post['email'], FILTER_VALIDATE_EMAIL))) {
+			$this->error['email'] = $this->language->get('error_email');
+		}
+
+		if ($this->request->post['payment'] == 'cheque') {
+			if ($this->request->post['cheque'] == '') {
+				$this->error['cheque'] = $this->language->get('error_cheque');
+			}
+		} elseif ($this->request->post['payment'] == 'paypal') {
+			if ((utf8_strlen($this->request->post['paypal']) > 96) || !filter_var($this->request->post['paypal'], FILTER_VALIDATE_EMAIL)) {
+				$this->error['paypal'] = $this->language->get('error_paypal');
+			}
+		} elseif ($this->request->post['payment'] == 'bank') {
+			if ($this->request->post['bank_account_name'] == '') {
+				$this->error['bank_account_name'] = $this->language->get('error_bank_account_name');
+			}
+
+			if ($this->request->post['bank_account_number'] == '') {
+				$this->error['bank_account_number'] = $this->language->get('error_bank_account_number');
+			}
+		}
+
+		$affiliate_info = $this->model_marketing_affiliate->getAffiliateByEmail($this->request->post['email']);
+
+		if (!isset($this->request->get['affiliate_id'])) {
+			if ($affiliate_info) {
+				$this->error['warning'] = $this->language->get('error_exists');
+			}
+		} else {
+			if ($affiliate_info && ($this->request->get['affiliate_id'] != $affiliate_info['affiliate_id'])) {
+				$this->error['warning'] = $this->language->get('error_exists');
+			}
+		}
+
+		if ((utf8_strlen($this->request->post['telephone']) < 3) || (utf8_strlen($this->request->post['telephone']) > 32)) {
+			$this->error['telephone'] = $this->language->get('error_telephone');
+		}
+
+		if ($this->request->post['password'] || (!isset($this->request->get['affiliate_id']))) {
+			if ((utf8_strlen($this->request->post['password']) < 4) || (utf8_strlen($this->request->post['password']) > 20)) {
+				$this->error['password'] = $this->language->get('error_password');
+			}
+
+			if ($this->request->post['password'] != $this->request->post['confirm']) {
+				$this->error['confirm'] = $this->language->get('error_confirm');
+			}
+		}
+
+		if ((utf8_strlen(trim($this->request->post['address_1'])) < 3) || (utf8_strlen(trim($this->request->post['address_1'])) > 128)) {
+			$this->error['address_1'] = $this->language->get('error_address_1');
+		}
+
+		if ((utf8_strlen(trim($this->request->post['city'])) < 2) || (utf8_strlen(trim($this->request->post['city'])) > 128)) {
+			$this->error['city'] = $this->language->get('error_city');
+		}
+
+		$this->load->model('localisation/country');
+
+		$country_info = $this->model_localisation_country->getCountry($this->request->post['country_id']);
+
+		if ($country_info && $country_info['postcode_required'] && (utf8_strlen(trim($this->request->post['postcode'])) < 2 || utf8_strlen(trim($this->request->post['postcode'])) > 10)) {
+			$this->error['postcode'] = $this->language->get('error_postcode');
+		}
+
+		if ($this->request->post['country_id'] == '') {
+			$this->error['country'] = $this->language->get('error_country');
+		}
+
+		if (!isset($this->request->post['zone_id']) || $this->request->post['zone_id'] == '') {
+			$this->error['zone'] = $this->language->get('error_zone');
+		}
+
+		if (!$this->request->post['code']) {
+			$this->error['code'] = $this->language->get('error_code');
+		}
+
+		if ($this->error && !isset($this->error['warning'])) {
+			$this->error['warning'] = $this->language->get('error_warning');
+		}
+
+		return (empty($this->error));
+	}
+
+	protected function validateDelete() {
+		if (!$this->user->hasPermission('modify', 'marketing/affiliate')) {
+			$this->error['warning'] = $this->language->get('error_permission');
+		}
+
+		return (empty($this->error));
+	}
+
+	protected function validateApprove() {
+		if (!$this->user->hasPermission('modify', 'marketing/affiliate')) {
+			$this->error['warning'] = $this->language->get('error_permission');
+		}
+
+		return (empty($this->error));
+	}
+
+	protected function validateUnlock() {
+		if (!$this->user->hasPermission('modify', 'marketing/affiliate')) {
+			$this->error['warning'] = $this->language->get('error_permission');
+		}
+
+		return (empty($this->error));
+	}
+
+	public function transaction() {
+		$this->language->load('marketing/affiliate');
+
+		$this->load->model('marketing/affiliate');
+
+		if (($this->request->server['REQUEST_METHOD'] == 'POST') && $this->user->hasPermission('modify', 'marketing/affiliate')) {
+			$this->model_marketing_affiliate->addTransaction($this->request->get['affiliate_id'], $this->request->post['description'], $this->request->post['amount']);
+
+			$this->data['success'] = $this->language->get('text_success');
+		} else {
+			$this->data['success'] = '';
+		}
+
+		if (($this->request->server['REQUEST_METHOD'] == 'POST') && !$this->user->hasPermission('modify', 'marketing/affiliate')) {
+			$this->data['error_warning'] = $this->language->get('error_permission');
+		} else {
+			$this->data['error_warning'] = '';
+		}
+
+		$this->data['text_no_results'] = $this->language->get('text_no_results');
+		$this->data['text_balance'] = $this->language->get('text_balance');
+
+		$this->data['column_date_added'] = $this->language->get('column_date_added');
+		$this->data['column_description'] = $this->language->get('column_description');
+		$this->data['column_amount'] = $this->language->get('column_amount');
+
+		if (isset($this->request->get['page'])) {
+			$page = $this->request->get['page'];
+		} else {
+			$page = 1;
+		}
+
+		// Pagination
+		$this->data['navigation_hi'] = $this->config->get('config_pagination_hi');
+		$this->data['navigation_lo'] = $this->config->get('config_pagination_lo');
+
+		$this->data['transactions'] = array();
+
+		$results = $this->model_marketing_affiliate->getTransactions($this->request->get['affiliate_id'], ($page - 1) * 10, 10);
+
+		foreach ($results as $result) {
+			$this->data['transactions'][] = array(
+				'amount'      => $this->currency->format($result['amount'], $this->config->get('config_currency')),
+				'description' => $result['description'],
+				'date_added'  => date($this->language->get('date_format_short'), strtotime($result['date_added']))
+			);
+		}
+
+		$this->data['balance'] = $this->currency->format($this->model_marketing_affiliate->getTransactionTotal($this->request->get['affiliate_id']), $this->config->get('config_currency'));
+
+		$transaction_total = $this->model_marketing_affiliate->getTotalTransactions($this->request->get['affiliate_id']);
+
+		$pagination = new Pagination();
+		$pagination->total = $transaction_total;
+		$pagination->page = $page;
+		$pagination->limit = $this->config->get('config_admin_limit');
+		$pagination->text = $this->language->get('text_pagination');
+		$pagination->url = $this->url->link('marketing/affiliate/transaction', 'token=' . $this->session->data['token'] . '&affiliate_id=' . $this->request->get['affiliate_id'] . '&page={page}', 'SSL');
+
+		$this->data['pagination'] = $pagination->render();
+
+		$this->data['results'] = sprintf($this->language->get('text_pagination'), ($transaction_total) ? (($page - 1) * $this->config->get('config_admin_limit')) + 1 : 0, ((($page - 1) * $this->config->get('config_admin_limit')) > ($transaction_total - $this->config->get('config_admin_limit'))) ? $transaction_total : ((($page - 1) * $this->config->get('config_admin_limit')) + $this->config->get('config_admin_limit')), $transaction_total, ceil($transaction_total / $this->config->get('config_admin_limit')));
+
+		$this->template = 'marketing/affiliate_transaction.tpl';
+
+		$this->response->setOutput($this->render());
+	}
+
+	public function addTransaction() {
+		$this->language->load('marketing/affiliate');
+
+		$json = array();
+
+		if (!$this->user->hasPermission('modify', 'marketing/affiliate')) {
+			$json['error'] = $this->language->get('error_permission');
+		} else {
+			$this->load->model('marketing/affiliate');
+
+			$this->model_marketing_affiliate->addTransaction($this->request->get['affiliate_id'], $this->request->post['description'], $this->request->post['amount']);
+
+			$json['success'] = $this->language->get('text_success');
+		}
+
+		$this->response->addHeader('Content-Type: application/json');
+		$this->response->setOutput(json_encode($json));
+	}
+
+	public function autocomplete() {
+		$affiliate_data = array();
+
+		if (isset($this->request->get['filter_name']) || isset($this->request->get['filter_email'])) {
+			if (isset($this->request->get['filter_name'])) {
+				$filter_name = $this->request->get['filter_name'];
+			} else {
+				$filter_name = '';
+			}
+
+			if (isset($this->request->get['filter_email'])) {
+				$filter_email = $this->request->get['filter_email'];
+			} else {
+				$filter_email = '';
+			}
+
+			$this->load->model('marketing/affiliate');
+
+			$filter_data = array(
+				'filter_name'  => $filter_name,
+				'filter_email' => $filter_email,
+				'start'        => 0,
+				'limit'        => 20
+			);
+
+			$results = $this->model_marketing_affiliate->getAffiliates($filter_data);
+
+			foreach ($results as $result) {
+				$affiliate_data[] = array(
+					'affiliate_id' => $result['affiliate_id'],
+					'name'         => strip_tags(html_entity_decode($result['name'], ENT_QUOTES, 'UTF-8')),
+					'email'        => html_entity_decode($result['email'], ENT_QUOTES, 'UTF-8')
+				);
+			}
+		}
+
+		$this->response->addHeader('Content-Type: application/json');
+		$this->response->setOutput(json_encode($affiliate_data));
+	}
+}
+?>

--- a/upload/admin/controller/marketing/contact.php
+++ b/upload/admin/controller/marketing/contact.php
@@ -1,0 +1,272 @@
+<?php
+class ControllerMarketingContact extends Controller {
+	private $error = array();
+
+	public function index() {
+		$this->language->load('marketing/contact');
+
+		$this->document->setTitle($this->language->get('heading_title'));
+
+		$this->data['heading_title'] = $this->language->get('heading_title');
+
+		$this->data['text_default'] = $this->language->get('text_default');
+		$this->data['text_newsletter'] = $this->language->get('text_newsletter');
+		$this->data['text_customer_all'] = $this->language->get('text_customer_all');
+		$this->data['text_customer'] = $this->language->get('text_customer');
+		$this->data['text_customer_group'] = $this->language->get('text_customer_group');
+		$this->data['text_affiliate_all'] = $this->language->get('text_affiliate_all');
+		$this->data['text_affiliate'] = $this->language->get('text_affiliate');
+		$this->data['text_product'] = $this->language->get('text_product');
+		$this->data['text_loading'] = $this->language->get('text_loading');
+
+		$this->data['entry_store'] = $this->language->get('entry_store');
+		$this->data['entry_to'] = $this->language->get('entry_to');
+		$this->data['entry_customer_group'] = $this->language->get('entry_customer_group');
+		$this->data['entry_customer'] = $this->language->get('entry_customer');
+		$this->data['entry_affiliate'] = $this->language->get('entry_affiliate');
+		$this->data['entry_product'] = $this->language->get('entry_product');
+		$this->data['entry_subject'] = $this->language->get('entry_subject');
+		$this->data['entry_message'] = $this->language->get('entry_message');
+
+		$this->data['help_customer'] = $this->language->get('help_customer');
+		$this->data['help_affiliate'] = $this->language->get('help_affiliate');
+		$this->data['help_product'] = $this->language->get('help_product');
+
+		$this->data['button_send'] = $this->language->get('button_send');
+		$this->data['button_cancel'] = $this->language->get('button_cancel');
+
+		$this->data['token'] = $this->session->data['token'];
+
+		$this->data['breadcrumbs'] = array();
+
+		$this->data['breadcrumbs'][] = array(
+			'text' => $this->language->get('text_home'),
+			'href' => $this->url->link('common/home', 'token=' . $this->session->data['token'], 'SSL'),
+			'separator' => false
+		);
+
+		$this->data['breadcrumbs'][] = array(
+			'text' => $this->language->get('heading_title'),
+			'href' => $this->url->link('marketing/contact', 'token=' . $this->session->data['token'], 'SSL'),
+			'separator' => ' :: '
+		);
+
+		$this->data['cancel'] = $this->url->link('common/home', 'token=' . $this->session->data['token'], 'SSL');
+
+		$this->load->model('setting/store');
+
+		$this->data['stores'] = $this->model_setting_store->getStores();
+
+		$this->load->model('sale/customer_group');
+
+		$this->data['customer_groups'] = $this->model_sale_customer_group->getCustomerGroups(0);
+
+		$this->template = 'marketing/contact.tpl';
+		$this->children = array(
+			'common/header',
+			'common/footer'
+		);
+
+		$this->response->setOutput($this->render());
+	}
+
+	public function send() {
+		$this->language->load('marketing/contact');
+
+		$json = array();
+
+		if ($this->request->server['REQUEST_METHOD'] == 'POST') {
+			if (!$this->user->hasPermission('modify', 'marketing/contact')) {
+				$json['error']['warning'] = $this->language->get('error_permission');
+			}
+
+			if (!$this->request->post['subject']) {
+				$json['error']['subject'] = $this->language->get('error_subject');
+			}
+
+			if (!$this->request->post['message']) {
+				$json['error']['message'] = $this->language->get('error_message');
+			}
+
+			if (array_key_exists('error', $json) && !array_key_exists('warning', $json['error'])) {
+				$json['error']['warning'] = $this->language->get('error_warning');
+			}
+
+			if (empty($json)) {
+				$this->load->model('setting/store');
+
+				$store_info = $this->model_setting_store->getStore($this->request->post['store_id']);
+
+				if ($store_info) {
+					$store_name = $store_info['name'];
+				} else {
+					$store_name = $this->config->get('config_name');
+				}
+
+				$this->load->model('setting/setting');
+				$setting = $this->model_setting_setting->getSetting('config', $this->request->post['store_id']);
+				$store_email = isset($setting['config_email']) ? $setting['config_email'] : $this->config->get('config_email');
+
+				$this->load->model('sale/customer');
+
+				$this->load->model('sale/customer_group');
+
+				$this->load->model('marketing/affiliate');
+
+				$this->load->model('sale/order');
+
+				if (isset($this->request->get['page'])) {
+					$page = $this->request->get['page'];
+				} else {
+					$page = 1;
+				}
+
+				$email_total = 0;
+
+				$emails = array();
+
+				switch ($this->request->post['to']) {
+					case 'newsletter':
+						$customer_data = array(
+							'filter_newsletter' => 1,
+							'start'             => ($page - 1) * 10,
+							'limit'             => 10
+						);
+
+						$email_total = $this->model_sale_customer->getTotalCustomers($customer_data);
+
+						$results = $this->model_sale_customer->getCustomers($customer_data);
+
+						foreach ($results as $result) {
+							$emails[] = $result['email'];
+						}
+						break;
+					case 'customer_all':
+						$customer_data = array(
+							'start' => ($page - 1) * 10,
+							'limit' => 10
+						);
+
+						$email_total = $this->model_sale_customer->getTotalCustomers($customer_data);
+
+						$results = $this->model_sale_customer->getCustomers($customer_data);
+
+						foreach ($results as $result) {
+							$emails[] = $result['email'];
+						}
+						break;
+					case 'customer_group':
+						$customer_data = array(
+							'filter_customer_group_id' => $this->request->post['customer_group_id'],
+							'start'                    => ($page - 1) * 10,
+							'limit'                    => 10
+						);
+
+						$email_total = $this->model_sale_customer->getTotalCustomers($customer_data);
+
+						$results = $this->model_sale_customer->getCustomers($customer_data);
+
+						foreach ($results as $result) {
+							$emails[$result['customer_id']] = $result['email'];
+						}
+						break;
+					case 'customer':
+						if (!empty($this->request->post['customer'])) {
+							foreach ($this->request->post['customer'] as $customer_id) {
+								$customer_info = $this->model_sale_customer->getCustomer($customer_id);
+
+								if ($customer_info) {
+									$emails[] = $customer_info['email'];
+								}
+							}
+						}
+						break;
+					case 'affiliate_all':
+						$affiliate_data = array(
+							'start' => ($page - 1) * 10,
+							'limit' => 10
+						);
+
+						$email_total = $this->model_marketing_affiliate->getTotalAffiliates($affiliate_data);
+
+						$results = $this->model_marketing_affiliate->getAffiliates($affiliate_data);
+
+						foreach ($results as $result) {
+							$emails[] = $result['email'];
+						}
+						break;
+					case 'affiliate':
+						if (!empty($this->request->post['affiliate'])) {
+							foreach ($this->request->post['affiliate'] as $affiliate_id) {
+								$affiliate_info = $this->model_marketing_affiliate->getAffiliate($affiliate_id);
+
+								if ($affiliate_info) {
+									$emails[] = $affiliate_info['email'];
+								}
+							}
+						}
+						break;
+					case 'product':
+						if (isset($this->request->post['product'])) {
+							$email_total = $this->model_sale_order->getTotalEmailsByProductsOrdered($this->request->post['product']);
+
+							$results = $this->model_sale_order->getEmailsByProductsOrdered($this->request->post['product'], ($page - 1) * 10, 10);
+
+							foreach ($results as $result) {
+								$emails[] = $result['email'];
+							}
+						}
+						break;
+				}
+
+				if (!empty($emails)) {
+					$start = ($page - 1) * 10;
+					$end = $start + 10;
+
+					if ($end < $email_total) {
+						$json['success'] = sprintf($this->language->get('text_sent'), $start, $email_total);
+					} else {
+						$json['success'] = $this->language->get('text_success');
+					}
+
+					if ($end < $email_total) {
+						$json['next'] = str_replace('&amp;', '&', $this->url->link('marketing/contact/send', 'token=' . $this->session->data['token'] . '&page=' . ($page + 1), 'SSL'));
+					} else {
+						$json['next'] = '';
+					}
+
+					$message  = '<html dir="ltr" lang="en">' . "\n";
+					$message .= '  <head>' . "\n";
+					$message .= '    <title>' . $this->request->post['subject'] . '</title>' . "\n";
+					$message .= '    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">' . "\n";
+					$message .= '  </head>' . "\n";
+					$message .= '  <body>' . html_entity_decode($this->request->post['message'], ENT_QUOTES, 'UTF-8') . '</body>' . "\n";
+					$message .= '</html>' . "\n";
+
+					foreach ($emails as $email) {
+						if (preg_match('/^[^\@]+@.*.[a-z]{2,15}$/i', $email)) {
+							$mail = new Mail();
+							$mail->protocol = $this->config->get('config_mail_protocol');
+							$mail->parameter = $this->config->get('config_mail_parameter');
+							$mail->hostname = $this->config->get('config_smtp_host');
+							$mail->username = $this->config->get('config_smtp_username');
+							$mail->password = html_entity_decode($this->config->get('config_smtp_password'), ENT_QUOTES, 'UTF-8');
+							$mail->port = $this->config->get('config_smtp_port');
+							$mail->timeout = $this->config->get('config_smtp_timeout');
+							$mail->setTo($email);
+							$mail->setFrom($store_email);
+							$mail->setSender(html_entity_decode($store_name, ENT_QUOTES, 'UTF-8'));
+							$mail->setSubject(html_entity_decode($this->request->post['subject'], ENT_QUOTES, 'UTF-8'));
+							$mail->setHtml($message);
+							$mail->send();
+						}
+					}
+				}
+			}
+		}
+
+		$this->response->addHeader('Content-Type: application/json');
+		$this->response->setOutput(json_encode($json));
+	}
+}
+?>

--- a/upload/admin/controller/marketing/coupon.php
+++ b/upload/admin/controller/marketing/coupon.php
@@ -1,0 +1,688 @@
+<?php
+class	ControllerMarketingCoupon	extends	Controller {
+	private	$error = array();
+
+	public function	index()	{
+		$this->language->load('marketing/coupon');
+
+		$this->document->setTitle($this->language->get('heading_title'));
+
+		$this->load->model('marketing/coupon');
+
+		$this->getList();
+	}
+
+	public function	insert() {
+		$this->language->load('marketing/coupon');
+
+		$this->document->setTitle($this->language->get('heading_title'));
+
+		$this->load->model('marketing/coupon');
+
+		if (($this->request->server['REQUEST_METHOD']	== 'POST') &&	$this->validateForm()) {
+			$new_coupon_id = $this->model_marketing_coupon->addCoupon($this->request->post);
+
+			$this->session->data['success']	=	$this->language->get('text_success');
+
+			$url = '';
+
+			if (isset($this->request->get['sort']))	{
+				$url .=	'&sort=' . $this->request->get['sort'];
+			}
+
+			if (isset($this->request->get['order'])) {
+				$url .=	'&order='	.	$this->request->get['order'];
+			}
+
+			if (isset($this->request->get['page']))	{
+				$url .=	'&page=' . $this->request->get['page'];
+			}
+
+			if (isset($this->request->post['apply']))	{
+
+				if ($new_coupon_id)	{
+					$this->redirect($this->url->link('marketing/coupon/update',	'token=' . $this->session->data['token'] . '&coupon_id=' . $coupon_id	.	$url,	'SSL'));
+				}
+
+			}	else {
+				$this->redirect($this->url->link('marketing/coupon', 'token='	.	$this->session->data['token']	.	$url,	'SSL'));
+			}
+		}
+
+		$this->getForm();
+	}
+
+	public function	update() {
+		$this->language->load('marketing/coupon');
+
+		$this->document->setTitle($this->language->get('heading_title'));
+
+		$this->load->model('marketing/coupon');
+
+		if (($this->request->server['REQUEST_METHOD']	== 'POST') &&	$this->validateForm()) {
+			$this->model_marketing_coupon->editCoupon($this->request->get['coupon_id'],	$this->request->post);
+
+			$this->session->data['success']	=	$this->language->get('text_success');
+
+			$url = '';
+
+			if (isset($this->request->get['sort']))	{
+				$url .=	'&sort=' . $this->request->get['sort'];
+			}
+
+			if (isset($this->request->get['order'])) {
+				$url .=	'&order='	.	$this->request->get['order'];
+			}
+
+			if (isset($this->request->get['page']))	{
+				$url .=	'&page=' . $this->request->get['page'];
+			}
+
+			if (isset($this->request->post['apply']))	{
+				$coupon_id = $this->request->get['coupon_id'];
+
+				if ($coupon_id)	{
+					$this->redirect($this->url->link('marketing/coupon/update',	'token=' . $this->session->data['token'] . '&coupon_id=' . $coupon_id	.	$url,	'SSL'));
+				}
+
+			}	else {
+				$this->redirect($this->url->link('marketing/coupon', 'token='	.	$this->session->data['token']	.	$url,	'SSL'));
+			}
+		}
+
+		$this->getForm();
+	}
+
+	public function	delete() {
+		$this->language->load('marketing/coupon');
+
+		$this->document->setTitle($this->language->get('heading_title'));
+
+		$this->load->model('marketing/coupon');
+
+		if (isset($this->request->post['selected'])	&& $this->validateDelete())	{
+			foreach	($this->request->post['selected']	as $coupon_id) {
+				$this->model_marketing_coupon->deleteCoupon($coupon_id);
+			}
+
+			$this->session->data['success']	=	$this->language->get('text_success');
+
+			$url = '';
+
+			if (isset($this->request->get['sort']))	{
+				$url .=	'&sort=' . $this->request->get['sort'];
+			}
+
+			if (isset($this->request->get['order'])) {
+				$url .=	'&order='	.	$this->request->get['order'];
+			}
+
+			if (isset($this->request->get['page']))	{
+				$url .=	'&page=' . $this->request->get['page'];
+			}
+
+			$this->redirect($this->url->link('marketing/coupon', 'token='	.	$this->session->data['token']	.	$url,	'SSL'));
+		}
+
+		$this->getList();
+	}
+
+	protected	function getList() {
+		if (isset($this->request->get['sort']))	{
+			$sort	=	$this->request->get['sort'];
+		}	else {
+			$sort	=	'name';
+		}
+
+		if (isset($this->request->get['order'])) {
+			$order = $this->request->get['order'];
+		}	else {
+			$order = 'ASC';
+		}
+
+		if (isset($this->request->get['page']))	{
+			$page	=	$this->request->get['page'];
+		}	else {
+			$page	=	1;
+		}
+
+		$url = '';
+
+		if (isset($this->request->get['sort']))	{
+			$url .=	'&sort=' . $this->request->get['sort'];
+		}
+
+		if (isset($this->request->get['order'])) {
+			$url .=	'&order='	.	$this->request->get['order'];
+		}
+
+		if (isset($this->request->get['page']))	{
+			$url .=	'&page=' . $this->request->get['page'];
+		}
+
+		$this->data['breadcrumbs'] = array();
+
+		$this->data['breadcrumbs'][] = array(
+			'text'			=> $this->language->get('text_home'),
+			'href'			=> $this->url->link('common/home', 'token='	.	$this->session->data['token'], 'SSL'),
+			'separator'	=> false
+		);
+
+		$this->data['breadcrumbs'][] = array(
+			'text'			=> $this->language->get('heading_title'),
+			'href'			=> $this->url->link('marketing/coupon',	'token=' . $this->session->data['token'] . $url, 'SSL'),
+			'separator'	=> ' ::	'
+		);
+
+		$this->data['insert']	=	$this->url->link('marketing/coupon/insert',	'token=' . $this->session->data['token'] . $url, 'SSL');
+		$this->data['delete']	=	$this->url->link('marketing/coupon/delete',	'token=' . $this->session->data['token'] . $url, 'SSL');
+
+		// Pagination
+		$this->data['navigation_hi'] = $this->config->get('config_pagination_hi');
+		$this->data['navigation_lo'] = $this->config->get('config_pagination_lo');
+
+		$this->data['coupons'] = array();
+
+		$filter_data = array(
+			'sort'	=> $sort,
+			'order'	=> $order,
+			'start'	=> ($page	-	1) * $this->config->get('config_admin_limit'),
+			'limit'	=> $this->config->get('config_admin_limit')
+		);
+
+		$coupon_total	=	$this->model_marketing_coupon->getTotalCoupons();
+
+		$results = $this->model_marketing_coupon->getCoupons($filter_data);
+
+		foreach	($results	as $result)	{
+			$action	=	array();
+
+			$action[]	=	array(
+				'text' =>	$this->language->get('text_edit'),
+				'href' =>	$this->url->link('marketing/coupon/update',	'token=' . $this->session->data['token'] . '&coupon_id=' . $result['coupon_id']	.	$url,	'SSL')
+			);
+
+			$this->data['coupons'][] = array(
+				'coupon_id'	 =>	$result['coupon_id'],
+				'name'			 =>	$result['name'],
+				'code'			 =>	$result['code'],
+				'type'			 =>	$result['type']	== 'P' ? '%' : ' ',
+				'discount'	 =>	$result['discount'],
+				'date_start' =>	date($this->language->get('date_format_short'),	strtotime($result['date_start'])),
+				'date_end'	 =>	date($this->language->get('date_format_short'),	strtotime($result['date_end'])),
+				'status'		 =>	$result['status'],
+				'selected'	 =>	isset($this->request->post['selected'])	&& in_array($result['coupon_id'],	$this->request->post['selected']),
+				'action'		 =>	$action
+			);
+		}
+
+		$this->data['heading_title'] = $this->language->get('heading_title');
+
+		$this->data['text_no_results'] = $this->language->get('text_no_results');
+		$this->data['text_enabled']	=	$this->language->get('text_enabled');
+		$this->data['text_disabled'] = $this->language->get('text_disabled');
+
+		$this->data['column_name'] = $this->language->get('column_name');
+		$this->data['column_code'] = $this->language->get('column_code');
+		$this->data['column_discount'] = $this->language->get('column_discount');
+		$this->data['column_date_start'] = $this->language->get('column_date_start');
+		$this->data['column_date_end'] = $this->language->get('column_date_end');
+		$this->data['column_status'] = $this->language->get('column_status');
+		$this->data['column_action'] = $this->language->get('column_action');
+
+		$this->data['button_insert'] = $this->language->get('button_insert');
+		$this->data['button_update'] = $this->language->get('button_update');
+		$this->data['button_delete'] = $this->language->get('button_delete');
+
+		$this->data['token'] = $this->session->data['token'];
+
+		if (isset($this->error['warning']))	{
+			$this->data['error_warning'] = $this->error['warning'];
+		}	else {
+			$this->data['error_warning'] = '';
+		}
+
+		if (isset($this->session->data['success']))	{
+			$this->data['success'] = $this->session->data['success'];
+
+			unset($this->session->data['success']);
+		}	else {
+			$this->data['success'] = '';
+		}
+
+		if (isset($this->request->post['selected'])) {
+			$this->data['selected']	=	(array)$this->request->post['selected'];
+		}	else {
+			$this->data['selected']	=	array();
+		}
+
+		$url = '';
+
+		if ($order ==	'ASC') {
+			$url .=	'&order=DESC';
+		}	else {
+			$url .=	'&order=ASC';
+		}
+
+		if (isset($this->request->get['page']))	{
+			$url .=	'&page=' . $this->request->get['page'];
+		}
+
+		$this->data['sort_name'] = $this->url->link('marketing/coupon',	'token=' . $this->session->data['token'] . '&sort=name'	.	$url,	'SSL');
+		$this->data['sort_code'] = $this->url->link('marketing/coupon',	'token=' . $this->session->data['token'] . '&sort=code'	.	$url,	'SSL');
+		$this->data['sort_discount'] = $this->url->link('marketing/coupon',	'token=' . $this->session->data['token'] . '&sort=discount'	.	$url,	'SSL');
+		$this->data['sort_date_start'] = $this->url->link('marketing/coupon',	'token=' . $this->session->data['token'] . '&sort=date_start'	.	$url,	'SSL');
+		$this->data['sort_date_end'] = $this->url->link('marketing/coupon',	'token=' . $this->session->data['token'] . '&sort=date_end'	.	$url,	'SSL');
+		$this->data['sort_status'] = $this->url->link('marketing/coupon',	'token=' . $this->session->data['token'] . '&sort=status'	.	$url,	'SSL');
+
+		$url = '';
+
+		if (isset($this->request->get['sort']))	{
+			$url .=	'&sort=' . $this->request->get['sort'];
+		}
+
+		if (isset($this->request->get['order'])) {
+			$url .=	'&order='	.	$this->request->get['order'];
+		}
+
+		$pagination	=	new	Pagination();
+		$pagination->total = $coupon_total;
+		$pagination->page	=	$page;
+		$pagination->limit = $this->config->get('config_admin_limit');
+		$pagination->text	=	$this->language->get('text_pagination');
+		$pagination->url = $this->url->link('marketing/coupon',	'token=' . $this->session->data['token'] . $url	.	'&page={page}',	'SSL');
+
+		$this->data['pagination']	=	$pagination->render();
+
+		$this->data['results'] = sprintf($this->language->get('text_pagination'),	($coupon_total)	?	(($page	-	1) * $this->config->get('config_admin_limit')) + 1 : 0,	((($page - 1)	*	$this->config->get('config_admin_limit'))	>	($coupon_total - $this->config->get('config_admin_limit')))	?	$coupon_total	:	((($page - 1)	*	$this->config->get('config_admin_limit'))	+	$this->config->get('config_admin_limit')), $coupon_total,	ceil($coupon_total / $this->config->get('config_admin_limit')));
+
+		$this->data['sort']	=	$sort;
+		$this->data['order'] = $order;
+
+		$this->template	=	'marketing/coupon_list.tpl';
+		$this->children	=	array(
+			'common/header',
+			'common/footer'
+		);
+
+		$this->response->setOutput($this->render());
+	}
+
+	protected	function getForm() {
+		$this->data['heading_title'] = $this->language->get('heading_title');
+
+		$this->data['text_form'] = !isset($this->request->get['coupon_id'])	?	$this->language->get('text_insert')	:	$this->language->get('text_update');
+		$this->data['text_enabled']	=	$this->language->get('text_enabled');
+		$this->data['text_disabled'] = $this->language->get('text_disabled');
+		$this->data['text_yes']	=	$this->language->get('text_yes');
+		$this->data['text_no'] = $this->language->get('text_no');
+		$this->data['text_percent']	=	$this->language->get('text_percent');
+		$this->data['text_amount'] = $this->language->get('text_amount');
+
+		$this->data['entry_name']	=	$this->language->get('entry_name');
+		$this->data['entry_description'] = $this->language->get('entry_description');
+		$this->data['entry_code']	=	$this->language->get('entry_code');
+		$this->data['entry_discount']	=	$this->language->get('entry_discount');
+		$this->data['entry_logged']	=	$this->language->get('entry_logged');
+		$this->data['entry_shipping']	=	$this->language->get('entry_shipping');
+		$this->data['entry_type']	=	$this->language->get('entry_type');
+		$this->data['entry_total'] = $this->language->get('entry_total');
+		$this->data['entry_category']	=	$this->language->get('entry_category');
+		$this->data['entry_product'] = $this->language->get('entry_product');
+		$this->data['entry_date_start']	=	$this->language->get('entry_date_start');
+		$this->data['entry_date_end']	=	$this->language->get('entry_date_end');
+		$this->data['entry_uses_total']	=	$this->language->get('entry_uses_total');
+		$this->data['entry_uses_customer'] = $this->language->get('entry_uses_customer');
+		$this->data['entry_status']	=	$this->language->get('entry_status');
+
+		$this->data['help_code'] = $this->language->get('help_code');
+		$this->data['help_type'] = $this->language->get('help_type');
+		$this->data['help_logged'] = $this->language->get('help_logged');
+		$this->data['help_total']	=	$this->language->get('help_total');
+		$this->data['help_category'] = $this->language->get('help_category');
+		$this->data['help_product']	=	$this->language->get('help_product');
+		$this->data['help_uses_total'] = $this->language->get('help_uses_total');
+		$this->data['help_uses_customer']	=	$this->language->get('help_uses_customer');
+
+		$this->data['button_save'] = $this->language->get('button_save');
+		$this->data['button_apply']	=	$this->language->get('button_apply');
+		$this->data['button_cancel'] = $this->language->get('button_cancel');
+
+		$this->data['tab_general'] = $this->language->get('tab_general');
+		$this->data['tab_history'] = $this->language->get('tab_history');
+
+		$this->data['token'] = $this->session->data['token'];
+
+		if (isset($this->error['warning']))	{
+			$this->data['error_warning'] = $this->error['warning'];
+		}	else {
+			$this->data['error_warning'] = '';
+		}
+
+		if (isset($this->session->data['success']))	{
+			$this->data['success'] = $this->session->data['success'];
+
+			unset($this->session->data['success']);
+		}	else {
+			$this->data['success'] = '';
+		}
+
+		if (isset($this->request->get['coupon_id'])) {
+			$this->data['coupon_id'] = $this->request->get['coupon_id'];
+		}	else {
+			$this->data['coupon_id'] = 0;
+		}
+
+		if (isset($this->error['warning']))	{
+			$this->data['error_warning'] = $this->error['warning'];
+		}	else {
+			$this->data['error_warning'] = '';
+		}
+
+		if (isset($this->error['name'])) {
+			$this->data['error_name']	=	$this->error['name'];
+		}	else {
+			$this->data['error_name']	=	'';
+		}
+
+		if (isset($this->error['code'])) {
+			$this->data['error_code']	=	$this->error['code'];
+		}	else {
+			$this->data['error_code']	=	'';
+		}
+
+		if (isset($this->error['date_start'])) {
+			$this->data['error_date_start']	=	$this->error['date_start'];
+		}	else {
+			$this->data['error_date_start']	=	'';
+		}
+
+		if (isset($this->error['date_end'])) {
+			$this->data['error_date_end']	=	$this->error['date_end'];
+		}	else {
+			$this->data['error_date_end']	=	'';
+		}
+
+		$url = '';
+
+		if (isset($this->request->get['sort']))	{
+			$url .=	'&sort=' . $this->request->get['sort'];
+		}
+
+		if (isset($this->request->get['order'])) {
+			$url .=	'&order='	.	$this->request->get['order'];
+		}
+
+		if (isset($this->request->get['page']))	{
+			$url .=	'&page=' . $this->request->get['page'];
+		}
+
+		$this->data['breadcrumbs'] = array();
+
+		$this->data['breadcrumbs'][] = array(
+			'text'			=> $this->language->get('text_home'),
+			'href'			=> $this->url->link('common/home', 'token='	.	$this->session->data['token'], 'SSL'),
+			'separator'	=> false
+		);
+
+		$this->data['breadcrumbs'][] = array(
+			'text'			=> $this->language->get('heading_title'),
+			'href'			=> $this->url->link('marketing/coupon',	'token=' . $this->session->data['token'] . $url, 'SSL'),
+			'separator'	=> ' ::	'
+		);
+
+		if (!isset($this->request->get['coupon_id']))	{
+			$this->data['action']	=	$this->url->link('marketing/coupon/insert',	'token=' . $this->session->data['token'] . $url, 'SSL');
+		}	else {
+			$this->data['action']	=	$this->url->link('marketing/coupon/update',	'token=' . $this->session->data['token'] . '&coupon_id=' . $this->request->get['coupon_id']	.	$url,	'SSL');
+		}
+
+		$this->data['cancel']	=	$this->url->link('marketing/coupon', 'token='	.	$this->session->data['token']	.	$url,	'SSL');
+
+		if (isset($this->request->get['coupon_id'])	&& (!$this->request->server['REQUEST_METHOD']	!= 'POST'))	{
+			$coupon_info = $this->model_marketing_coupon->getCoupon($this->request->get['coupon_id']);
+		}
+
+		if (isset($this->request->post['name'])) {
+			$this->data['name']	=	$this->request->post['name'];
+		}	elseif (!empty($coupon_info))	{
+			$this->data['name']	=	$coupon_info['name'];
+		}	else {
+			$this->data['name']	=	'';
+		}
+
+		if (isset($this->request->post['code'])) {
+			$this->data['code']	=	$this->request->post['code'];
+		}	elseif (!empty($coupon_info))	{
+			$this->data['code']	=	$coupon_info['code'];
+		}	else {
+			$this->data['code']	=	'';
+		}
+
+		if (isset($this->request->post['type'])) {
+			$this->data['type']	=	$this->request->post['type'];
+		}	elseif (!empty($coupon_info))	{
+			$this->data['type']	=	$coupon_info['type'];
+		}	else {
+			$this->data['type']	=	'';
+		}
+
+		if (isset($this->request->post['discount'])) {
+			$this->data['discount']	=	$this->request->post['discount'];
+		}	elseif (!empty($coupon_info))	{
+			$this->data['discount']	=	$coupon_info['discount'];
+		}	else {
+			$this->data['discount']	=	'';
+		}
+
+		if (isset($this->request->post['logged'])) {
+			$this->data['logged']	=	$this->request->post['logged'];
+		}	elseif (!empty($coupon_info))	{
+			$this->data['logged']	=	$coupon_info['logged'];
+		}	else {
+			$this->data['logged']	=	'';
+		}
+
+		if (isset($this->request->post['shipping'])) {
+			$this->data['shipping']	=	$this->request->post['shipping'];
+		}	elseif (!empty($coupon_info))	{
+			$this->data['shipping']	=	$coupon_info['shipping'];
+		}	else {
+			$this->data['shipping']	=	'';
+		}
+
+		if (isset($this->request->post['total']))	{
+			$this->data['total'] = $this->request->post['total'];
+		}	elseif (!empty($coupon_info))	{
+			$this->data['total'] = $coupon_info['total'];
+		}	else {
+			$this->data['total'] = '';
+		}
+
+		if (isset($this->request->post['coupon_product'])) {
+			$products	=	$this->request->post['coupon_product'];
+		}	elseif (isset($this->request->get['coupon_id'])) {
+			$products	=	$this->model_marketing_coupon->getCouponProducts($this->request->get['coupon_id']);
+		}	else {
+			$products	=	array();
+		}
+
+		$this->load->model('catalog/product');
+
+		$this->data['coupon_products'] = array();
+
+		foreach	($products as	$product_id) {
+			$product_info	=	$this->model_catalog_product->getProduct($product_id);
+
+			if ($product_info) {
+				$this->data['coupon_products'][] = array(
+					'product_id' =>	$product_info['product_id'],
+					'name'			 =>	$product_info['name']
+				);
+			}
+		}
+
+		if (isset($this->request->post['coupon_category']))	{
+			$categories	=	$this->request->post['coupon_category'];
+		}	elseif (isset($this->request->get['coupon_id'])) {
+			$categories	=	$this->model_marketing_coupon->getCouponCategories($this->request->get['coupon_id']);
+		}	else {
+			$categories	=	array();
+		}
+
+		$this->load->model('catalog/category');
+
+		$this->data['coupon_categories'] = array();
+
+		foreach	($categories as	$category_id)	{
+			$category_info = $this->model_catalog_category->getCategory($category_id);
+
+			if ($category_info)	{
+				$this->data['coupon_categories'][] = array(
+					'category_id'	=> $category_info['category_id'],
+					'name'				=> ($category_info['path'] ? $category_info['path']	.	'	&gt; ' : '') . $category_info['name']
+				);
+			}
+		}
+
+		if (isset($this->request->post['date_start'])) {
+			$this->data['date_start']	=	$this->request->post['date_start'];
+		}	elseif (!empty($coupon_info))	{
+			$this->data['date_start']	=	($coupon_info['date_start']	!= '0000-00-00'	?	$coupon_info['date_start'] : '');
+		}	else {
+			$this->data['date_start']	=	date('Y-m-d',	time());
+		}
+
+		if (isset($this->request->post['date_end'])) {
+			$this->data['date_end']	=	$this->request->post['date_end'];
+		}	elseif (!empty($coupon_info))	{
+			$this->data['date_end']	=	($coupon_info['date_end']	!= '0000-00-00'	?	$coupon_info['date_end'] : '');
+		}	else {
+			$this->data['date_end']	=	date('Y-m-d',	strtotime('+1	month'));
+		}
+
+		if (isset($this->request->post['uses_total'])) {
+			$this->data['uses_total']	=	$this->request->post['uses_total'];
+		}	elseif (!empty($coupon_info))	{
+			$this->data['uses_total']	=	$coupon_info['uses_total'];
+		}	else {
+			$this->data['uses_total']	=	1;
+		}
+
+		if (isset($this->request->post['uses_customer']))	{
+			$this->data['uses_customer'] = $this->request->post['uses_customer'];
+		}	elseif (!empty($coupon_info))	{
+			$this->data['uses_customer'] = $coupon_info['uses_customer'];
+		}	else {
+			$this->data['uses_customer'] = 1;
+		}
+
+		if (isset($this->request->post['status'])) {
+			$this->data['status']	=	$this->request->post['status'];
+		}	elseif (!empty($coupon_info))	{
+			$this->data['status']	=	$coupon_info['status'];
+		}	else {
+			$this->data['status']	=	true;
+		}
+
+		$this->template	=	'marketing/coupon_form.tpl';
+		$this->children	=	array(
+			'common/header',
+			'common/footer'
+		);
+
+		$this->response->setOutput($this->render());
+	}
+
+	protected	function validateForm()	{
+		if (!$this->user->hasPermission('modify',	'marketing/coupon')) {
+			$this->error['warning']	=	$this->language->get('error_permission');
+		}
+
+		if ((utf8_strlen($this->request->post['name']) < 3)	|| (utf8_strlen($this->request->post['name'])	>	128))	{
+			$this->error['name'] = $this->language->get('error_name');
+		}
+
+		if ((utf8_strlen($this->request->post['code']) < 3)	|| (utf8_strlen($this->request->post['code'])	>	10)) {
+			$this->error['code'] = $this->language->get('error_code');
+		}
+
+		$coupon_info = $this->model_marketing_coupon->getCouponByCode($this->request->post['code']);
+
+		if ($coupon_info)	{
+			if (!isset($this->request->get['coupon_id']))	{
+				$this->error['warning']	=	$this->language->get('error_exists');
+			}	elseif ($coupon_info['coupon_id']	!= $this->request->get['coupon_id']) {
+				$this->error['warning']	=	$this->language->get('error_exists');
+			}
+		}
+
+		if ($this->error &&	!isset($this->error['warning'])) {
+			$this->error['warning']	=	$this->language->get('error_warning');
+		}
+
+		return (empty($this->error));
+	}
+
+	protected	function validateDelete()	{
+		if (!$this->user->hasPermission('modify',	'marketing/coupon')) {
+			$this->error['warning']	=	$this->language->get('error_permission');
+		}
+
+		return (empty($this->error));
+	}
+
+	public function	history()	{
+		$this->language->load('marketing/coupon');
+
+		$this->load->model('marketing/coupon');
+
+		$this->data['text_no_results'] = $this->language->get('text_no_results');
+
+		$this->data['column_order_id'] = $this->language->get('column_order_id');
+		$this->data['column_customer'] = $this->language->get('column_customer');
+		$this->data['column_date_added'] = $this->language->get('column_date_added');
+		$this->data['column_amount'] = $this->language->get('column_amount');
+
+		if (isset($this->request->get['page']))	{
+			$page	=	$this->request->get['page'];
+		}	else {
+			$page	=	1;
+		}
+
+		// Pagination
+		$this->data['navigation_hi'] = $this->config->get('config_pagination_hi');
+		$this->data['navigation_lo'] = $this->config->get('config_pagination_lo');
+
+		$this->data['histories'] = array();
+
+		$results = $this->model_marketing_coupon->getCouponHistories($this->request->get['coupon_id'], ($page	-	1) * 10, 10);
+
+		foreach	($results	as $result)	{
+			$this->data['histories'][] = array(
+				'order_id'	 =>	$result['order_id'],
+				'customer'	 =>	$result['customer'],
+				'date_added' =>	date($this->language->get('date_format_time'), strtotime($result['date_added'])),
+				'amount'		 =>	$result['amount']
+			);
+		}
+
+		$history_total = $this->model_marketing_coupon->getTotalCouponHistories($this->request->get['coupon_id']);
+
+		$pagination	=	new	Pagination();
+		$pagination->total = $history_total;
+		$pagination->page	=	$page;
+		$pagination->limit = $this->config->get('config_admin_limit');
+		$pagination->text	=	$this->language->get('text_pagination');
+		$pagination->url = $this->url->link('marketing/coupon/history',	'token=' . $this->session->data['token'] . '&coupon_id=' . $this->request->get['coupon_id']	.	'&page={page}',	'SSL');
+
+		$this->data['pagination']	=	$pagination->render();
+
+		$this->data['results'] = sprintf($this->language->get('text_pagination'),	($history_total) ? (($page - 1)	*	$this->config->get('config_admin_limit'))	+	1	:	0, ((($page	-	1) * $this->config->get('config_admin_limit')) > ($history_total - $this->config->get('config_admin_limit')))	?	$history_total : ((($page	-	1) * $this->config->get('config_admin_limit')) + $this->config->get('config_admin_limit')),	$history_total,	ceil($history_total	/	$this->config->get('config_admin_limit')));
+
+		$this->template	=	'marketing/coupon_history.tpl';
+
+		$this->response->setOutput($this->render());
+	}
+}
+?>

--- a/upload/admin/controller/marketing/marketing.php
+++ b/upload/admin/controller/marketing/marketing.php
@@ -1,0 +1,570 @@
+<?php
+class ControllerMarketingMarketing extends Controller {
+	private $error = array();
+
+	public function index() {
+		$this->language->load('marketing/marketing');
+
+		$this->document->setTitle($this->language->get('heading_title'));
+
+		$this->load->model('marketing/marketing');
+
+		$this->getList();
+	}
+
+	public function insert() {
+		$this->language->load('marketing/marketing');
+
+		$this->document->setTitle($this->language->get('heading_title'));
+
+		$this->load->model('marketing/marketing');
+
+		if (($this->request->server['REQUEST_METHOD'] == 'POST') && $this->validateForm()) {
+			$this->model_marketing_marketing->addMarketing($this->request->post);
+
+			$this->session->data['success'] = $this->language->get('text_success');
+
+			$url = '';
+
+			if (isset($this->request->get['filter_name'])) {
+				$url .= '&filter_name=' . urlencode(html_entity_decode($this->request->get['filter_name'], ENT_QUOTES, 'UTF-8'));
+			}
+
+			if (isset($this->request->get['filter_code'])) {
+				$url .= '&filter_code=' . $this->request->get['filter_code'];
+			}
+
+			if (isset($this->request->get['filter_date_added'])) {
+				$url .= '&filter_date_added=' . $this->request->get['filter_date_added'];
+			}
+
+			if (isset($this->request->get['sort'])) {
+				$url .= '&sort=' . $this->request->get['sort'];
+			}
+
+			if (isset($this->request->get['order'])) {
+				$url .= '&order=' . $this->request->get['order'];
+			}
+
+			if (isset($this->request->get['page'])) {
+				$url .= '&page=' . $this->request->get['page'];
+			}
+
+			if (isset($this->request->post['apply'])) {
+
+				if ($new_marketing_id) {
+					$this->redirect($this->url->link('marketing/marketing/update', 'token=' . $this->session->data['token'] . '&marketing_id=' . $marketing_id . $url, 'SSL'));
+				}
+
+			} else {
+				$this->redirect($this->url->link('marketing/marketing', 'token=' . $this->session->data['token'] . $url, 'SSL'));
+			}
+		}
+
+		$this->getForm();
+	}
+
+	public function update() {
+		$this->language->load('marketing/marketing');
+
+		$this->document->setTitle($this->language->get('heading_title'));
+
+		$this->load->model('marketing/marketing');
+
+		if (($this->request->server['REQUEST_METHOD'] == 'POST') && $this->validateForm()) {
+			$this->model_marketing_marketing->editMarketing($this->request->get['marketing_id'], $this->request->post);
+
+			$this->session->data['success'] = $this->language->get('text_success');
+
+			$url = '';
+
+			if (isset($this->request->get['filter_name'])) {
+				$url .= '&filter_name=' . urlencode(html_entity_decode($this->request->get['filter_name'], ENT_QUOTES, 'UTF-8'));
+			}
+
+			if (isset($this->request->get['filter_code'])) {
+				$url .= '&filter_code=' . $this->request->get['filter_code'];
+			}
+
+			if (isset($this->request->get['filter_date_added'])) {
+				$url .= '&filter_date_added=' . $this->request->get['filter_date_added'];
+			}
+
+			if (isset($this->request->get['sort'])) {
+				$url .= '&sort=' . $this->request->get['sort'];
+			}
+
+			if (isset($this->request->get['order'])) {
+				$url .= '&order=' . $this->request->get['order'];
+			}
+
+			if (isset($this->request->get['page'])) {
+				$url .= '&page=' . $this->request->get['page'];
+			}
+
+			if (isset($this->request->post['apply'])) {
+				$marketing_id = $this->request->get['marketing_id'];
+
+				if ($marketing_id) {
+					$this->redirect($this->url->link('marketing/marketing/update', 'token=' . $this->session->data['token'] . '&marketing_id=' . $marketing_id . $url, 'SSL'));
+				}
+
+			} else {
+				$this->redirect($this->url->link('marketing/marketing', 'token=' . $this->session->data['token'] . $url, 'SSL'));
+			}
+		}
+
+		$this->getForm();
+	}
+
+	public function delete() {
+		$this->language->load('marketing/marketing');
+
+		$this->document->setTitle($this->language->get('heading_title'));
+
+		$this->load->model('marketing/marketing');
+
+		if (isset($this->request->post['selected']) && $this->validateDelete()) {
+			foreach ($this->request->post['selected'] as $marketing_id) {
+				$this->model_marketing_marketing->deleteMarketing($marketing_id);
+			}
+
+			$this->session->data['success'] = $this->language->get('text_success');
+
+			$url = '';
+
+			if (isset($this->request->get['filter_name'])) {
+				$url .= '&filter_name=' . urlencode(html_entity_decode($this->request->get['filter_name'], ENT_QUOTES, 'UTF-8'));
+			}
+
+			if (isset($this->request->get['filter_code'])) {
+				$url .= '&filter_code=' . $this->request->get['filter_code'];
+			}
+
+			if (isset($this->request->get['filter_date_added'])) {
+				$url .= '&filter_date_added=' . $this->request->get['filter_date_added'];
+			}
+
+			if (isset($this->request->get['sort'])) {
+				$url .= '&sort=' . $this->request->get['sort'];
+			}
+
+			if (isset($this->request->get['order'])) {
+				$url .= '&order=' . $this->request->get['order'];
+			}
+
+			if (isset($this->request->get['page'])) {
+				$url .= '&page=' . $this->request->get['page'];
+			}
+
+			$this->response->redirect($this->url->link('marketing/marketing', 'token=' . $this->session->data['token'] . $url, 'SSL'));
+		}
+
+		$this->getList();
+	}
+
+	protected function getList() {
+		if (isset($this->request->get['filter_name'])) {
+			$filter_name = $this->request->get['filter_name'];
+		} else {
+			$filter_name = null;
+		}
+
+		if (isset($this->request->get['filter_code'])) {
+			$filter_code = $this->request->get['filter_code'];
+		} else {
+			$filter_code = null;
+		}
+
+		if (isset($this->request->get['filter_date_added'])) {
+			$filter_date_added = $this->request->get['filter_date_added'];
+		} else {
+			$filter_date_added = null;
+		}
+
+		if (isset($this->request->get['sort'])) {
+			$sort = $this->request->get['sort'];
+		} else {
+			$sort = 'name';
+		}
+
+		if (isset($this->request->get['order'])) {
+			$order = $this->request->get['order'];
+		} else {
+			$order = 'ASC';
+		}
+
+		if (isset($this->request->get['page'])) {
+			$page = $this->request->get['page'];
+		} else {
+			$page = 1;
+		}
+
+		$url = '';
+
+		if (isset($this->request->get['filter_name'])) {
+			$url .= '&filter_name=' . urlencode(html_entity_decode($this->request->get['filter_name'], ENT_QUOTES, 'UTF-8'));
+		}
+
+		if (isset($this->request->get['filter_code'])) {
+			$url .= '&filter_code=' . $this->request->get['filter_code'];
+		}
+
+		if (isset($this->request->get['filter_date_added'])) {
+			$url .= '&filter_date_added=' . $this->request->get['filter_date_added'];
+		}
+
+		if (isset($this->request->get['sort'])) {
+			$url .= '&sort=' . $this->request->get['sort'];
+		}
+
+		if (isset($this->request->get['sort'])) {
+			$url .= '&sort=' . $this->request->get['sort'];
+		}
+
+		if (isset($this->request->get['order'])) {
+			$url .= '&order=' . $this->request->get['order'];
+		}
+
+		if (isset($this->request->get['page'])) {
+			$url .= '&page=' . $this->request->get['page'];
+		}
+
+		$this->data['breadcrumbs'] = array();
+
+		$this->data['breadcrumbs'][] = array(
+			'text' => $this->language->get('text_home'),
+			'href'      => $this->url->link('common/home', 'token=' . $this->session->data['token'], 'SSL'),
+			'separator' => false
+		);
+
+		$this->data['breadcrumbs'][] = array(
+			'text' => $this->language->get('heading_title'),
+			'href'      => $this->url->link('marketing/marketing', 'token=' . $this->session->data['token'] . $url, 'SSL'),
+			'separator' => ' :: '
+		);
+
+		$this->data['insert'] = $this->url->link('marketing/marketing/insert', 'token=' . $this->session->data['token'] . $url, 'SSL');
+		$this->data['delete'] = $this->url->link('marketing/marketing/delete', 'token=' . $this->session->data['token'] . $url, 'SSL');
+
+		// Pagination
+		$this->data['navigation_hi'] = $this->config->get('config_pagination_hi');
+		$this->data['navigation_lo'] = $this->config->get('config_pagination_lo');
+
+		$this->data['marketings'] = array();
+
+		$filter_data = array(
+			'filter_name'       => $filter_name,
+			'filter_code'       => $filter_code,
+			'filter_date_added' => $filter_date_added,
+			'sort'              => $sort,
+			'order'             => $order,
+			'start'             => ($page - 1) * $this->config->get('config_admin_limit'),
+			'limit'             => $this->config->get('config_admin_limit')
+		);
+
+		$marketing_total = $this->model_marketing_marketing->getTotalMarketings($filter_data);
+
+		$results = $this->model_marketing_marketing->getMarketings($filter_data);
+
+		foreach ($results as $result) {
+			$action = array();
+
+			$action[] = array(
+				'text' => $this->language->get('text_edit'),
+				'href' => $this->url->link('marketing/marketing/update', 'token=' . $this->session->data['token'] . '&marketing_id=' . $result['marketing_id'] . $url, 'SSL')
+			);
+
+			$this->data['marketings'][] = array(
+				'marketing_id' => $result['marketing_id'],
+				'name'         => $result['name'],
+				'code'         => $result['code'],
+				'clicks'       => $result['clicks'],
+				'orders'       => $result['orders'],
+				'date_added'   => date($this->language->get('date_format_short'), strtotime($result['date_added'])),
+				'selected'     => isset($this->request->post['selected']) && in_array($result['coupon_id'], $this->request->post['selected']),
+				'action'       => $action
+			);
+		}
+
+		$this->data['heading_title'] = $this->language->get('heading_title');
+
+		$this->data['text_no_results'] = $this->language->get('text_no_results');
+		$this->data['text_confirm'] = $this->language->get('text_confirm');
+
+		$this->data['column_name'] = $this->language->get('column_name');
+		$this->data['column_code'] = $this->language->get('column_code');
+		$this->data['column_clicks'] = $this->language->get('column_clicks');
+		$this->data['column_orders'] = $this->language->get('column_orders');
+		$this->data['column_date_added'] = $this->language->get('column_date_added');
+		$this->data['column_action'] = $this->language->get('column_action');
+
+		$this->data['entry_name'] = $this->language->get('entry_name');
+		$this->data['entry_code'] = $this->language->get('entry_code');
+		$this->data['entry_date_added'] = $this->language->get('entry_date_added');
+
+		$this->data['button_insert'] = $this->language->get('button_insert');
+		$this->data['button_update'] = $this->language->get('button_update');
+		$this->data['button_delete'] = $this->language->get('button_delete');
+		$this->data['button_filter'] = $this->language->get('button_filter');
+
+		$this->data['token'] = $this->session->data['token'];
+
+		if (isset($this->error['warning'])) {
+			$this->data['error_warning'] = $this->error['warning'];
+		} else {
+			$this->data['error_warning'] = '';
+		}
+
+		if (isset($this->session->data['success'])) {
+			$this->data['success'] = $this->session->data['success'];
+
+			unset($this->session->data['success']);
+		} else {
+			$this->data['success'] = '';
+		}
+
+		if (isset($this->request->post['selected'])) {
+			$this->data['selected'] = (array)$this->request->post['selected'];
+		} else {
+			$this->data['selected'] = array();
+		}
+
+		$url = '';
+
+		if (isset($this->request->get['filter_name'])) {
+			$url .= '&filter_name=' . urlencode(html_entity_decode($this->request->get['filter_name'], ENT_QUOTES, 'UTF-8'));
+		}
+
+		if (isset($this->request->get['filter_code'])) {
+			$url .= '&filter_code=' . $this->request->get['filter_code'];
+		}
+
+		if (isset($this->request->get['filter_date_added'])) {
+			$url .= '&filter_date_added=' . $this->request->get['filter_date_added'];
+		}
+
+		if ($order == 'ASC') {
+			$url .= '&order=DESC';
+		} else {
+			$url .= '&order=ASC';
+		}
+
+		if (isset($this->request->get['page'])) {
+			$url .= '&page=' . $this->request->get['page'];
+		}
+
+		$this->data['sort_name'] = $this->url->link('marketing/marketing', 'token=' . $this->session->data['token'] . '&sort=m.name' . $url, 'SSL');
+		$this->data['sort_code'] = $this->url->link('marketing/marketing', 'token=' . $this->session->data['token'] . '&sort=m.code' . $url, 'SSL');
+		$this->data['sort_date_added'] = $this->url->link('marketing/marketing', 'token=' . $this->session->data['token'] . '&sort=m.date_added' . $url, 'SSL');
+
+		$url = '';
+
+		if (isset($this->request->get['filter_name'])) {
+			$url .= '&filter_name=' . urlencode(html_entity_decode($this->request->get['filter_name'], ENT_QUOTES, 'UTF-8'));
+		}
+
+		if (isset($this->request->get['filter_code'])) {
+			$url .= '&filter_code=' . $this->request->get['filter_code'];
+		}
+
+		if (isset($this->request->get['filter_date_added'])) {
+			$url .= '&filter_date_added=' . $this->request->get['filter_date_added'];
+		}
+
+		if (isset($this->request->get['sort'])) {
+			$url .= '&sort=' . $this->request->get['sort'];
+		}
+
+		if (isset($this->request->get['order'])) {
+			$url .= '&order=' . $this->request->get['order'];
+		}
+
+		$pagination = new Pagination();
+		$pagination->total = $marketing_total;
+		$pagination->page = $page;
+		$pagination->limit = $this->config->get('config_admin_limit');
+		$pagination->text = $this->language->get('text_pagination');
+		$pagination->url = $this->url->link('marketing/marketing', 'token=' . $this->session->data['token'] . $url . '&page={page}', 'SSL');
+
+		$this->data['pagination'] = $pagination->render();
+
+		$this->data['results'] = sprintf($this->language->get('text_pagination'), ($marketing_total) ? (($page - 1) * $this->config->get('config_admin_limit')) + 1 : 0, ((($page - 1) * $this->config->get('config_admin_limit')) > ($marketing_total - $this->config->get('config_admin_limit'))) ? $marketing_total : ((($page - 1) * $this->config->get('config_admin_limit')) + $this->config->get('config_admin_limit')), $marketing_total, ceil($marketing_total / $this->config->get('config_admin_limit')));
+
+		$this->data['filter_name'] = $filter_name;
+		$this->data['filter_code'] = $filter_code;
+		$this->data['filter_date_added'] = $filter_date_added;
+
+		$this->data['sort'] = $sort;
+		$this->data['order'] = $order;
+
+		$this->template = 'marketing/marketing_list.tpl';
+		$this->children = array(
+			'common/header',
+			'common/footer'
+		);
+
+		$this->response->setOutput($this->render());
+	}
+
+	protected function getForm() {
+		$this->data['heading_title'] = $this->language->get('heading_title');
+
+		$this->data['text_form'] = !isset($this->request->get['marketing_id']) ? $this->language->get('text_insert') : $this->language->get('text_update');
+
+		$this->data['entry_name'] = $this->language->get('entry_name');
+		$this->data['entry_description'] = $this->language->get('entry_description');
+		$this->data['entry_code'] = $this->language->get('entry_code');
+		$this->data['entry_example'] = $this->language->get('entry_example');
+
+		$this->data['help_code'] = $this->language->get('help_code');
+		$this->data['help_example'] = $this->language->get('help_example');
+
+		$this->data['button_save'] = $this->language->get('button_save');
+		$this->data['button_apply'] = $this->language->get('button_apply');
+		$this->data['button_cancel'] = $this->language->get('button_cancel');
+
+		$this->data['token'] = $this->session->data['token'];
+
+    if (isset($this->error['warning'])) {
+      $this->data['error_warning'] = $this->error['warning'];
+    } else {
+      $this->data['error_warning'] = '';
+    }
+
+    if (isset($this->session->data['success'])) {
+      $this->data['success'] = $this->session->data['success'];
+
+      unset($this->session->data['success']);
+    } else {
+      $this->data['success'] = '';
+    }
+
+		if (isset($this->error['name'])) {
+			$this->data['error_name'] = $this->error['name'];
+		} else {
+			$this->data['error_name'] = '';
+		}
+
+		if (isset($this->error['code'])) {
+			$this->data['error_code'] = $this->error['code'];
+		} else {
+			$this->data['error_code'] = '';
+		}
+
+		$url = '';
+
+		if (isset($this->request->get['filter_name'])) {
+			$url .= '&filter_name=' . urlencode(html_entity_decode($this->request->get['filter_name'], ENT_QUOTES, 'UTF-8'));
+		}
+
+		if (isset($this->request->get['filter_code'])) {
+			$url .= '&filter_code=' . $this->request->get['filter_code'];
+		}
+
+		if (isset($this->request->get['filter_date_added'])) {
+			$url .= '&filter_date_added=' . $this->request->get['filter_date_added'];
+		}
+
+		if (isset($this->request->get['sort'])) {
+			$url .= '&sort=' . $this->request->get['sort'];
+		}
+
+		if (isset($this->request->get['order'])) {
+			$url .= '&order=' . $this->request->get['order'];
+		}
+
+		if (isset($this->request->get['page'])) {
+			$url .= '&page=' . $this->request->get['page'];
+		}
+
+		$this->data['breadcrumbs'] = array();
+
+		$this->data['breadcrumbs'][] = array(
+			'text' => $this->language->get('text_home'),
+			'href' => $this->url->link('common/dashboard', 'token=' . $this->session->data['token'], 'SSL'),
+			'separator' => false
+		);
+
+		$this->data['breadcrumbs'][] = array(
+			'text' => $this->language->get('heading_title'),
+			'href' => $this->url->link('marketing/marketing', 'token=' . $this->session->data['token'] . $url, 'SSL'),
+			'separator' => ' :: '
+		);
+
+		if (!isset($this->request->get['marketing_id'])) {
+			$this->data['action'] = $this->url->link('marketing/marketing/insert', 'token=' . $this->session->data['token'] . $url, 'SSL');
+		} else {
+			$this->data['action'] = $this->url->link('marketing/marketing/update', 'token=' . $this->session->data['token'] . '&marketing_id=' . $this->request->get['marketing_id'] . $url, 'SSL');
+		}
+
+		$this->data['cancel'] = $this->url->link('marketing/marketing', 'token=' . $this->session->data['token'] . $url, 'SSL');
+
+		if (isset($this->request->get['marketing_id']) && ($this->request->server['REQUEST_METHOD'] != 'POST')) {
+			$marketing_info = $this->model_marketing_marketing->getMarketing($this->request->get['marketing_id']);
+		}
+
+		$this->data['store'] = HTTP_CATALOG;
+
+		if (isset($this->request->post['name'])) {
+			$this->data['name'] = $this->request->post['name'];
+		} elseif (!empty($marketing_info)) {
+			$this->data['name'] = $marketing_info['name'];
+		} else {
+			$this->data['name'] = '';
+		}
+
+		if (isset($this->request->post['description'])) {
+			$this->data['description'] = $this->request->post['description'];
+		} elseif (!empty($marketing_info)) {
+			$this->data['description'] = $marketing_info['description'];
+		} else {
+			$this->data['description'] = '';
+		}
+
+		if (isset($this->request->post['code'])) {
+			$this->data['code'] = $this->request->post['code'];
+		} elseif (!empty($marketing_info)) {
+			$this->data['code'] = $marketing_info['code'];
+		} else {
+			$this->data['code'] = uniqid();
+		}
+
+		$this->template = 'marketing/marketing_form.tpl';
+		$this->children = array(
+			'common/header',
+			'common/footer'
+		);
+
+		$this->response->setOutput($this->render());
+	}
+
+	protected function validateForm() {
+		if (!$this->user->hasPermission('modify', 'marketing/marketing')) {
+			$this->error['warning'] = $this->language->get('error_permission');
+		}
+
+		if ((utf8_strlen($this->request->post['name']) < 1) || (utf8_strlen($this->request->post['name']) > 32)) {
+			$this->error['name'] = $this->language->get('error_name');
+		}
+
+		if (!$this->request->post['code']) {
+			$this->error['code'] = $this->language->get('error_code');
+		}
+
+    if ($this->error && !isset($this->error['warning'])) {
+      $this->error['warning'] = $this->language->get('error_warning');
+    }
+
+		return (empty($this->error));
+	}
+
+	protected function validateDelete() {
+		if (!$this->user->hasPermission('modify', 'marketing/marketing')) {
+			$this->error['warning'] = $this->language->get('error_permission');
+		}
+
+		return (empty($this->error));
+	}
+}
+?>

--- a/upload/admin/controller/module/affiliate.php
+++ b/upload/admin/controller/module/affiliate.php
@@ -1,5 +1,5 @@
 <?php
-class ControllerModuleAffiliate extends Controller { 
+class ControllerModuleAffiliate extends Controller {
 	private $error = array();
 	private $_name = 'affiliate';
 

--- a/upload/admin/controller/report/affiliate.php
+++ b/upload/admin/controller/report/affiliate.php
@@ -1,0 +1,147 @@
+<?php
+class ControllerReportAffiliate extends Controller {
+	public function index() {
+		$this->language->load('report/affiliate');
+
+		$this->document->setTitle($this->language->get('heading_title'));
+
+		if (isset($this->request->get['filter_date_start'])) {
+			$filter_date_start = $this->request->get['filter_date_start'];
+		} else {
+			$filter_date_start = '';
+		}
+
+		if (isset($this->request->get['filter_date_end'])) {
+			$filter_date_end = $this->request->get['filter_date_end'];
+		} else {
+			$filter_date_end = '';
+		}
+
+		if (isset($this->request->get['page'])) {
+			$page = $this->request->get['page'];
+		} else {
+			$page = 1;
+		}
+
+		$url = '';
+
+		if (isset($this->request->get['filter_date_start'])) {
+			$url .= '&filter_date_start=' . $this->request->get['filter_date_start'];
+		}
+
+		if (isset($this->request->get['filter_date_end'])) {
+			$url .= '&filter_date_end=' . $this->request->get['filter_date_end'];
+		}
+
+		if (isset($this->request->get['page'])) {
+			$url .= '&page=' . $this->request->get['page'];
+		}
+
+		$this->data['breadcrumbs'] = array();
+
+		$this->data['breadcrumbs'][] = array(
+			'text'      => $this->language->get('text_home'),
+			'href'      => $this->url->link('common/home', 'token=' . $this->session->data['token'], 'SSL'),
+			'separator' => false
+		);
+
+		$this->data['breadcrumbs'][] = array(
+			'text' => $this->language->get('heading_title'),
+			'href'      => $this->url->link('report/affiliate', 'token=' . $this->session->data['token'] . $url, 'SSL'),
+			'separator' => ' :: '
+		);
+
+		// Pagination
+		$this->data['navigation_hi'] = $this->config->get('config_pagination_hi');
+		$this->data['navigation_lo'] = $this->config->get('config_pagination_lo');
+
+		$this->load->model('report/affiliate');
+
+		$this->data['affiliates'] = array();
+
+		$filter_data = array(
+			'filter_date_start' => $filter_date_start,
+			'filter_date_end'   => $filter_date_end,
+			'start'             => ($page - 1) * $this->config->get('config_admin_limit'),
+			'limit'             => $this->config->get('config_admin_limit')
+		);
+
+		$affiliate_total = $this->model_report_affiliate->getTotalCommission($filter_data);
+
+		$results = $this->model_report_affiliate->getCommission($filter_data);
+
+		foreach ($results as $result) {
+			$action = array();
+
+			$action[] = array(
+				'text' => $this->language->get('text_edit'),
+				'href' => $this->url->link('marketing/affiliate/update', 'token=' . $this->session->data['token'] . '&affiliate_id=' . $result['affiliate_id'] . $url, 'SSL')
+			);
+
+			$this->data['affiliates'][] = array(
+				'affiliate'  => $result['affiliate'],
+				'email'      => $result['email'],
+				'status'     => ($result['status'] ? $this->language->get('text_enabled') : $this->language->get('text_disabled')),
+				'commission' => $this->currency->format($result['commission'], $this->config->get('config_currency')),
+				'orders'     => $result['orders'],
+				'total'      => $this->currency->format($result['total'], $this->config->get('config_currency')),
+				'action'     => $action
+			);
+		}
+
+		$this->data['heading_title'] = $this->language->get('heading_title');
+
+		$this->data['text_no_results'] = $this->language->get('text_no_results');
+
+		$this->data['column_affiliate'] = $this->language->get('column_affiliate');
+		$this->data['column_email'] = $this->language->get('column_email');
+		$this->data['column_status'] = $this->language->get('column_status');
+		$this->data['column_commission'] = $this->language->get('column_commission');
+		$this->data['column_orders'] = $this->language->get('column_orders');
+		$this->data['column_total'] = $this->language->get('column_total');
+		$this->data['column_action'] = $this->language->get('column_action');
+
+		$this->data['entry_date_start'] = $this->language->get('entry_date_start');
+		$this->data['entry_date_end'] = $this->language->get('entry_date_end');
+
+		$this->data['button_close'] = $this->language->get('button_close');
+		$this->data['button_filter'] = $this->language->get('button_filter');
+
+		$this->data['close'] = $this->url->link('common/home', 'token=' . $this->session->data['token'], 'SSL');
+
+		$this->data['token'] = $this->session->data['token'];
+
+		$url = '';
+
+		if (isset($this->request->get['filter_date_start'])) {
+			$url .= '&filter_date_start=' . $this->request->get['filter_date_start'];
+		}
+
+		if (isset($this->request->get['filter_date_end'])) {
+			$url .= '&filter_date_end=' . $this->request->get['filter_date_end'];
+		}
+
+		$pagination = new Pagination();
+		$pagination->total = $affiliate_total;
+		$pagination->page = $page;
+		$pagination->limit = $this->config->get('config_admin_limit');
+		$pagination->text = $this->language->get('text_pagination');
+		$pagination->url = $this->url->link('report/affiliate', 'token=' . $this->session->data['token'] . $url . '&page={page}', 'SSL');
+
+		$this->data['pagination'] = $pagination->render();
+
+		$this->data['results'] = sprintf($this->language->get('text_pagination'), ($affiliate_total) ? (($page - 1) * $this->config->get('config_admin_limit')) + 1 : 0, ((($page - 1) * $this->config->get('config_admin_limit')) > ($affiliate_total - $this->config->get('config_admin_limit'))) ? $affiliate_total : ((($page - 1) * $this->config->get('config_admin_limit')) + $this->config->get('config_admin_limit')), $affiliate_total, ceil($affiliate_total / $this->config->get('config_admin_limit')));
+
+		$this->data['filter_date_start'] = $filter_date_start;
+		$this->data['filter_date_end'] = $filter_date_end;
+
+		$this->template = 'report/affiliate.tpl';
+		$this->children = array(
+			'common/header',
+			'common/footer'
+		);
+
+		$this->response->setOutput($this->render());
+	}
+}
+?>

--- a/upload/admin/controller/report/affiliate_activity.php
+++ b/upload/admin/controller/report/affiliate_activity.php
@@ -1,0 +1,176 @@
+<?php
+class ControllerReportAffiliateActivity extends Controller {
+	public function index() {
+		$this->language->load('report/affiliate_activity');
+
+		$this->document->setTitle($this->language->get('heading_title'));
+
+		if (isset($this->request->get['filter_affiliate'])) {
+			$filter_affiliate = $this->request->get['filter_affiliate'];
+		} else {
+			$filter_affiliate = null;
+		}
+
+		if (isset($this->request->get['filter_ip'])) {
+			$filter_ip = $this->request->get['filter_ip'];
+		} else {
+			$filter_ip = null;
+		}
+
+		if (isset($this->request->get['filter_date_start'])) {
+			$filter_date_start = $this->request->get['filter_date_start'];
+		} else {
+			$filter_date_start = '';
+		}
+
+		if (isset($this->request->get['filter_date_end'])) {
+			$filter_date_end = $this->request->get['filter_date_end'];
+		} else {
+			$filter_date_end = '';
+		}
+
+		if (isset($this->request->get['page'])) {
+			$page = $this->request->get['page'];
+		} else {
+			$page = 1;
+		}
+
+		$url = '';
+
+		if (isset($this->request->get['filter_affiliate'])) {
+			$url .= '&filter_affiliate=' . urlencode($this->request->get['filter_affiliate']);
+		}
+
+		if (isset($this->request->get['filter_ip'])) {
+			$url .= '&filter_ip=' . $this->request->get['filter_ip'];
+		}
+
+		if (isset($this->request->get['filter_date_start'])) {
+			$url .= '&filter_date_start=' . $this->request->get['filter_date_start'];
+		}
+
+		if (isset($this->request->get['filter_date_end'])) {
+			$url .= '&filter_date_end=' . $this->request->get['filter_date_end'];
+		}
+
+		if (isset($this->request->get['page'])) {
+			$url .= '&page=' . $this->request->get['page'];
+		}
+
+		$this->data['breadcrumbs'] = array();
+
+		$this->data['breadcrumbs'][] = array(
+			'text'      => $this->language->get('text_home'),
+			'href'      => $this->url->link('common/home', 'token=' . $this->session->data['token'], 'SSL'),
+			'separator' => false
+		);
+
+		$this->data['breadcrumbs'][] = array(
+			'text'      => $this->language->get('heading_title'),
+			'href'      => $this->url->link('report/affiliate_activity', 'token=' . $this->session->data['token'] . $url, 'SSL'),
+			'separator' => ' :: '
+		);
+
+		// Pagination
+		$this->data['navigation_hi'] = $this->config->get('config_pagination_hi');
+		$this->data['navigation_lo'] = $this->config->get('config_pagination_lo');
+
+		$this->load->model('report/affiliate');
+
+		$this->data['activities'] = array();
+
+		$filter_data = array(
+			'filter_affiliate'   => $filter_affiliate,
+			'filter_ip'         => $filter_ip,
+			'filter_date_start' => $filter_date_start,
+			'filter_date_end' => $filter_date_end,
+			'start'             => ($page - 1) * $this->config->get('config_admin_limit'),
+			'limit'             => $this->config->get('config_admin_limit')
+		);
+
+		$activity_total = $this->model_report_affiliate->getTotalAffiliateActivities($filter_data);
+
+		$results = $this->model_report_affiliate->getAffiliateActivities($filter_data);
+
+		foreach ($results as $result) {
+			$action = array();
+
+			$action[] = array(
+				'text' => $this->language->get('text_edit'),
+				'href' => $this->url->link('marketing/affiliate/update', 'token=' . $this->session->data['token'] . '&affiliate_id=' . $result['affiliate_id'] . $url, 'SSL')
+			);
+
+			$comment = vsprintf($this->language->get('text_' . $result['key']), json_decode($result['data'], 'SSL'));
+
+			$this->data['activities'][] = array(
+				'comment'    => str_replace('affiliate_id=', $this->url->link('marketing/affiliate/update', 'token=' . $this->session->data['token'] . '&affiliate_id=', 'SSL'), $comment),
+				'ip'         => $result['ip'],
+				'date_added' => date($this->language->get('datetime_format'), strtotime($result['date_added'])),
+				'action'     => $action
+			);
+		}
+
+		$this->data['heading_title'] = $this->language->get('heading_title');
+
+		$this->data['text_no_results'] = $this->language->get('text_no_results');
+
+		$this->data['column_comment'] = $this->language->get('column_comment');
+		$this->data['column_ip'] = $this->language->get('column_ip');
+		$this->data['column_date_added'] = $this->language->get('column_date_added');
+
+		$this->data['entry_affiliate'] = $this->language->get('entry_affiliate');
+		$this->data['entry_ip'] = $this->language->get('entry_ip');
+		$this->data['entry_date_start'] = $this->language->get('entry_date_start');
+		$this->data['entry_date_end'] = $this->language->get('entry_date_end');
+
+		$this->data['button_close'] = $this->language->get('button_close');
+		$this->data['button_filter'] = $this->language->get('button_filter');
+
+		$this->data['close'] = $this->url->link('common/home', 'token=' . $this->session->data['token'], 'SSL');
+
+		$this->data['token'] = $this->session->data['token'];
+
+		$url = '';
+
+		if (isset($this->request->get['filter_affiliate'])) {
+			$url .= '&filter_affiliate=' . urlencode($this->request->get['filter_affiliate']);
+		}
+
+		if (isset($this->request->get['filter_ip'])) {
+			$url .= '&filter_ip=' . $this->request->get['filter_ip'];
+		}
+
+		if (isset($this->request->get['filter_date_start'])) {
+			$url .= '&filter_date_start=' . $this->request->get['filter_date_start'];
+		}
+
+		if (isset($this->request->get['filter_date_end'])) {
+			$url .= '&filter_date_end=' . $this->request->get['filter_date_end'];
+		}
+
+		$pagination = new Pagination();
+		$pagination->total = $activity_total;
+		$pagination->page = $page;
+		$pagination->limit = $this->config->get('config_admin_limit');
+		$pagination->text = $this->language->get('text_pagination');
+		$pagination->url = $this->url->link('report/affiliate_activity', 'token=' . $this->session->data['token'] . $url . '&page={page}', 'SSL');
+
+		$this->data['pagination'] = $pagination->render();
+
+		$this->data['results'] = sprintf($this->language->get('text_pagination'), ($activity_total) ? (($page - 1) * $this->config->get('config_limit_admin')) + 1 : 0, ((($page - 1) * $this->config->get('config_limit_admin')) > ($activity_total - $this->config->get('config_limit_admin'))) ? $activity_total : ((($page - 1) * $this->config->get('config_limit_admin')) + $this->config->get('config_limit_admin')), $activity_total, ceil($activity_total / $this->config->get('config_limit_admin')));
+
+		$this->data['filter_affiliate'] = $filter_affiliate;
+		$this->data['filter_ip'] = $filter_ip;
+		$this->data['filter_date_start'] = $filter_date_start;
+		$this->data['filter_date_end'] = $filter_date_end;
+
+		$this->template = 'report/affiliate_activity.tpl';
+		$this->children = array(
+			'common/header',
+			'common/footer'
+		);
+
+		$this->response->setOutput($this->render());
+	}
+}
+?>

--- a/upload/admin/controller/report/marketing.php
+++ b/upload/admin/controller/report/marketing.php
@@ -1,0 +1,167 @@
+<?php
+class ControllerReportMarketing extends Controller {
+	public function index() {
+		$this->language->load('report/marketing');
+
+		$this->document->setTitle($this->language->get('heading_title'));
+
+		if (isset($this->request->get['filter_date_start'])) {
+			$filter_date_start = $this->request->get['filter_date_start'];
+		} else {
+			$filter_date_start = '';
+		}
+
+		if (isset($this->request->get['filter_date_end'])) {
+			$filter_date_end = $this->request->get['filter_date_end'];
+		} else {
+			$filter_date_end = '';
+		}
+
+		if (isset($this->request->get['filter_order_status_id'])) {
+			$filter_order_status_id = $this->request->get['filter_order_status_id'];
+		} else {
+			$filter_order_status_id = 0;
+		}
+
+		if (isset($this->request->get['page'])) {
+			$page = $this->request->get['page'];
+		} else {
+			$page = 1;
+		}
+
+		$url = '';
+
+		if (isset($this->request->get['filter_date_start'])) {
+			$url .= '&filter_date_start=' . $this->request->get['filter_date_start'];
+		}
+
+		if (isset($this->request->get['filter_date_end'])) {
+			$url .= '&filter_date_end=' . $this->request->get['filter_date_end'];
+		}
+
+		if (isset($this->request->get['filter_order_status_id'])) {
+			$url .= '&filter_order_status_id=' . $this->request->get['filter_order_status_id'];
+		}
+
+		if (isset($this->request->get['page'])) {
+			$url .= '&page=' . $this->request->get['page'];
+		}
+
+		$this->data['breadcrumbs'] = array();
+
+		$this->data['breadcrumbs'][] = array(
+			'text' => $this->language->get('text_home'),
+			'href'      => $this->url->link('common/home', 'token=' . $this->session->data['token'], 'SSL'),
+			'separator' => false
+		);
+
+		$this->data['breadcrumbs'][] = array(
+			'text' => $this->language->get('heading_title'),
+			'href' => $this->url->link('report/marketing', 'token=' . $this->session->data['token'] . $url, 'SSL'),
+			'separator' => ' :: '
+		);
+
+		// Pagination
+		$this->data['navigation_hi'] = $this->config->get('config_pagination_hi');
+		$this->data['navigation_lo'] = $this->config->get('config_pagination_lo');
+
+		$this->load->model('report/marketing');
+
+		$this->data['marketings'] = array();
+
+		$filter_data = array(
+			'filter_date_start'      => $filter_date_start,
+			'filter_date_end'        => $filter_date_end,
+			'filter_order_status_id' => $filter_order_status_id,
+			'start'                  => ($page - 1) * $this->config->get('config_admin_limit'),
+			'limit'                  => $this->config->get('config_admin_limit')
+		);
+
+		$marketing_total = $this->model_report_marketing->getTotalMarketing($filter_data);
+
+		$results = $this->model_report_marketing->getMarketing($filter_data);
+
+		foreach ($results as $result) {
+			$action = array();
+
+			$action[] = array(
+				'text' => $this->language->get('text_edit'),
+				'href' => $this->url->link('marketing/marketing/update', 'token=' . $this->session->data['token'] . '&marketing_id=' . $result['marketing_id'] . $url, 'SSL')
+			);
+
+			$this->data['marketings'][] = array(
+				'campaign' => $result['campaign'],
+				'code'     => $result['code'],
+				'clicks'   => $result['clicks'],
+				'orders'   => $result['orders'],
+				'total'    => $this->currency->format($result['total'], $this->config->get('config_currency')),
+				'action'   => $action
+			);
+		}
+
+		$this->data['heading_title'] = $this->language->get('heading_title');
+
+		$this->data['text_no_results'] = $this->language->get('text_no_results');
+		$this->data['text_all_status'] = $this->language->get('text_all_status');
+
+		$this->data['column_campaign'] = $this->language->get('column_campaign');
+		$this->data['column_code'] = $this->language->get('column_code');
+		$this->data['column_clicks'] = $this->language->get('column_clicks');
+		$this->data['column_orders'] = $this->language->get('column_orders');
+		$this->data['column_total'] = $this->language->get('column_total');
+		$this->data['column_action'] = $this->language->get('column_action');
+
+		$this->data['entry_date_start'] = $this->language->get('entry_date_start');
+		$this->data['entry_date_end'] = $this->language->get('entry_date_end');
+		$this->data['entry_status'] = $this->language->get('entry_status');
+
+		$this->data['button_close'] = $this->language->get('button_close');
+		$this->data['button_filter'] = $this->language->get('button_filter');
+
+		$this->data['close'] = $this->url->link('common/home', 'token=' . $this->session->data['token'], 'SSL');
+
+		$this->data['token'] = $this->session->data['token'];
+
+		$this->load->model('localisation/order_status');
+
+		$this->data['order_statuses'] = $this->model_localisation_order_status->getOrderStatuses();
+
+		$url = '';
+
+		if (isset($this->request->get['filter_date_start'])) {
+			$url .= '&filter_date_start=' . $this->request->get['filter_date_start'];
+		}
+
+		if (isset($this->request->get['filter_date_end'])) {
+			$url .= '&filter_date_end=' . $this->request->get['filter_date_end'];
+		}
+
+		if (isset($this->request->get['filter_order_status_id'])) {
+			$url .= '&filter_order_status_id=' . $this->request->get['filter_order_status_id'];
+		}
+
+		$pagination = new Pagination();
+		$pagination->total = $marketing_total;
+		$pagination->page = $page;
+		$pagination->limit = $this->config->get('config_admin_limit');
+		$pagination->text = $this->language->get('text_pagination');
+		$pagination->url = $this->url->link('report/marketing', 'token=' . $this->session->data['token'] . $url . '&page={page}', 'SSL');
+
+		$this->data['pagination'] = $pagination->render();
+
+		$this->data['results'] = sprintf($this->language->get('text_pagination'), ($marketing_total) ? (($page - 1) * $this->config->get('config_admin_limit')) + 1 : 0, ((($page - 1) * $this->config->get('config_admin_limit')) > ($marketing_total - $this->config->get('config_admin_limit'))) ? $marketing_total : ((($page - 1) * $this->config->get('config_admin_limit')) + $this->config->get('config_admin_limit')), $marketing_total, ceil($marketing_total / $this->config->get('config_admin_limit')));
+
+		$this->data['filter_date_start'] = $filter_date_start;
+		$this->data['filter_date_end'] = $filter_date_end;
+		$this->data['filter_order_status_id'] = $filter_order_status_id;
+
+		$this->template = 'report/marketing.tpl';
+		$this->children = array(
+			'common/header',
+			'common/footer'
+		);
+
+		$this->response->setOutput($this->render());
+	}
+}
+?>

--- a/upload/admin/language/english/common/header.php
+++ b/upload/admin/language/english/common/header.php
@@ -57,6 +57,7 @@ $_['text_logged']                      = 'You are logged in as <span><b>%s</b></
 $_['text_logout']                      = 'Logout';
 $_['text_logs']                        = 'Logs';
 $_['text_manufacturer']                = 'Manufacturers';
+$_['text_marketing']                   = 'Marketing';
 $_['text_menu_manager']                = 'Menus';
 $_['text_modification']                = 'Modifications';
 $_['text_module']                      = 'Modules';

--- a/upload/admin/language/english/marketing/affiliate.php
+++ b/upload/admin/language/english/marketing/affiliate.php
@@ -1,0 +1,88 @@
+<?php
+// Heading
+$_['heading_title']             = 'Affiliates';
+
+// Text
+$_['text_success']              = 'Success: You have modified <b>Affiliates</b> !';
+$_['text_approved']             = 'You have approved %s accounts!';
+$_['text_unlock']               = 'Unlock';
+$_['text_affiliate_detail']     = 'Affiliate Details';
+$_['text_affiliate_address']    = 'Affiliate Address';
+$_['text_wait']                 = 'Please Wait!';
+$_['text_balance']              = 'Balance';
+$_['text_cheque']               = 'Cheque';
+$_['text_paypal']               = 'PayPal';
+$_['text_bank']                 = 'Bank Transfer';
+
+// Column
+$_['column_name']               = 'Affiliate Name';
+$_['column_email']              = 'E-Mail';
+$_['column_code']               = 'Tracking Code';
+$_['column_balance']            = 'Balance';
+$_['column_status']             = 'Status';
+$_['column_approved']           = 'Approved';
+$_['column_date_added']         = 'Date Added';
+$_['column_description']        = 'Description';
+$_['column_amount']             = 'Amount';
+$_['column_action']             = 'Action';
+
+// Entry
+$_['entry_firstname']           = 'First Name';
+$_['entry_lastname']            = 'Last Name';
+$_['entry_email']               = 'E-Mail';
+$_['entry_telephone']           = 'Telephone';
+$_['entry_fax']                 = 'Fax';
+$_['entry_status']              = 'Status';
+$_['entry_password']            = 'Password';
+$_['entry_confirm']             = 'Confirm';
+$_['entry_company']             = 'Company';
+$_['entry_website']             = 'Web Site';
+$_['entry_address_1']           = 'Address 1';
+$_['entry_address_2']           = 'Address 2';
+$_['entry_city']                = 'City';
+$_['entry_postcode']            = 'Postcode';
+$_['entry_country']             = 'Country';
+$_['entry_zone']                = 'Region / State';
+$_['entry_code']                = 'Tracking Code';
+$_['entry_commission']          = 'Commission (%)';
+$_['entry_tax']                 = 'Tax ID';
+$_['entry_payment']             = 'Payment Method';
+$_['entry_cheque']              = 'Cheque Payee Name';
+$_['entry_paypal']              = 'PayPal Email Account';
+$_['entry_bank_name']           = 'Bank Name';
+$_['entry_bank_branch_number']  = 'ABA/BSB number (Branch Number)';
+$_['entry_bank_swift_code']     = 'SWIFT Code';
+$_['entry_bank_account_name']   = 'Account Name';
+$_['entry_bank_account_number'] = 'Account Number';
+$_['entry_amount']              = 'Amount';
+$_['entry_description']         = 'Description';
+$_['entry_name']                = 'Affiliate Name';
+$_['entry_approved']            = 'Approved';
+$_['entry_date_added']          = 'Date Added';
+
+// Help
+$_['help_code']                 = 'The tracking code that will be used to track referrals.';
+$_['help_commission']           = 'Percentage the affiliate receives on each order.';
+$_['help_amount']               = 'Enter an amount without the currency symbol.';
+
+// Error
+$_['error_warning']             = 'Warning: Please check the form carefully for errors!';
+$_['error_permission']          = 'Warning: You do not have permission to modify <b>Affiliates</b> !';
+$_['error_exists']              = 'Warning: E-Mail Address is already registered!';
+$_['error_firstname']           = 'First Name must be between 1 and 32 characters!';
+$_['error_lastname']            = 'Last Name must be between 1 and 32 characters!';
+$_['error_email']               = 'E-Mail Address does not appear to be valid!';
+$_['error_cheque']              = 'Cheque Payee Name required!';
+$_['error_paypal']              = 'PayPal Email Address does not appear to be valid!';
+$_['error_bank_account_name']   = 'Account Name required!';
+$_['error_bank_account_number'] = 'Account Number required!';
+$_['error_telephone']           = 'Telephone must be between 3 and 32 characters!';
+$_['error_password']            = 'Password must be between 4 and 20 characters!';
+$_['error_confirm']             = 'Password and password confirmation do not match!';
+$_['error_address_1']           = 'Address 1 must be between 3 and 128 characters!';
+$_['error_city']                = 'City must be between 2 and 128 characters!';
+$_['error_postcode']            = 'Postcode must be between 2 and 10 characters for this country!';
+$_['error_country']             = 'Please select a country!';
+$_['error_zone']                = 'Please select a region / state!';
+$_['error_code']                = 'Tracking Code required!';
+?>

--- a/upload/admin/language/english/marketing/contact.php
+++ b/upload/admin/language/english/marketing/contact.php
@@ -1,0 +1,37 @@
+<?php
+// Heading
+$_['heading_title']        = 'Mail';
+
+// Text
+$_['text_success']         = 'Your message has been successfully sent!';
+$_['text_sent']            = 'Your message has been successfully sent to %s of %s recipients!';
+$_['text_default']         = 'Default';
+$_['text_newsletter']      = 'All Newsletter Subscribers';
+$_['text_customer_all']    = 'All Customers';
+$_['text_customer_group']  = 'Customer Group';
+$_['text_customer']        = 'Customers';
+$_['text_affiliate_all']   = 'All Affiliates';
+$_['text_affiliate']       = 'Affiliates';
+$_['text_product']         = 'Products';
+
+// Entry
+$_['entry_store']          = 'From';
+$_['entry_to']             = 'To';
+$_['entry_customer_group'] = 'Customer Group';
+$_['entry_customer']       = 'Customer';
+$_['entry_affiliate']      = 'Affiliate';
+$_['entry_product']        = 'Products';
+$_['entry_subject']        = 'Subject';
+$_['entry_message']        = 'Message';
+
+// Help
+$_['help_customer']        = '(Autocomplete)';
+$_['help_affiliate']       = '(Autocomplete)';
+$_['help_product']         = 'Send only to customers who have ordered products in the list. (Autocomplete)';
+
+// Error
+$_['error_warning']        = 'Warning: Please check the form carefully for errors!';
+$_['error_permission']     = 'Warning: You do not have permission to send E-Mails!';
+$_['error_subject']        = 'E-Mail Subject required!';
+$_['error_message']        = 'E-Mail Message required!';
+?>

--- a/upload/admin/language/english/marketing/coupon.php
+++ b/upload/admin/language/english/marketing/coupon.php
@@ -1,0 +1,58 @@
+<?php
+// Heading
+$_['heading_title']       = 'Coupons';
+
+// Text
+$_['text_success']        = 'Success: You have modified <b>Coupons</b> !';
+$_['text_list']           = 'Coupon List';
+$_['text_insert']         = 'Add Coupon';
+$_['text_update']         = 'Edit Coupon';
+$_['text_percent']        = 'Percentage';
+$_['text_amount']         = 'Fixed Amount';
+
+// Column
+$_['column_name']         = 'Coupon Name';
+$_['column_code']         = 'Code';
+$_['column_discount']     = 'Discount';
+$_['column_date_start']   = 'Date Start';
+$_['column_date_end']     = 'Date End';
+$_['column_status']       = 'Status';
+$_['column_order_id']     = 'Order ID';
+$_['column_customer']     = 'Customer';
+$_['column_amount']       = 'Amount';
+$_['column_date_added']   = 'Date Added';
+$_['column_action']       = 'Action';
+
+// Entry
+$_['entry_name']          = 'Coupon Name';
+$_['entry_code']          = 'Code';
+$_['entry_type']          = 'Type';
+$_['entry_discount']      = 'Discount';
+$_['entry_logged']        = 'Customer Login';
+$_['entry_shipping']      = 'Free Shipping';
+$_['entry_total']         = 'Total Amount';
+$_['entry_category']      = 'Category';
+$_['entry_product']       = 'Products';
+$_['entry_date_start']    = 'Date Start';
+$_['entry_date_end']      = 'Date End';
+$_['entry_uses_total']    = 'Uses Per Coupon';
+$_['entry_uses_customer'] = 'Uses Per Customer';
+$_['entry_status']        = 'Status';
+
+// Help
+$_['help_code']           = 'The code the customer enters to get the discount.';
+$_['help_type']           = 'Percentage or Fixed Amount.';
+$_['help_logged']         = 'Customer must be logged in to use the coupon.';
+$_['help_total']          = 'The total amount that must be reached before the coupon is valid.';
+$_['help_category']       = 'Choose all products under selected category.';
+$_['help_product']        = 'Choose specific products the coupon will apply to. Select no products to apply coupon to entire cart.';
+$_['help_uses_total']     = 'The maximum number of times the coupon can be used by any customer. Leave blank for unlimited';
+$_['help_uses_customer']  = 'The maximum number of times the coupon can be used by a single customer. Leave blank for unlimited';
+
+// Error
+$_['error_warning']       = 'Warning: Please check the form carefully for errors!';
+$_['error_permission']    = 'Warning: You do not have permission to modify <b>Coupons</b> !';
+$_['error_exists']        = 'Warning: Coupon code is already in use!';
+$_['error_name']          = 'Coupon Name must be between 3 and 128 characters!';
+$_['error_code']          = 'Code must be between 3 and 10 characters!';
+?>

--- a/upload/admin/language/english/marketing/marketing.php
+++ b/upload/admin/language/english/marketing/marketing.php
@@ -1,0 +1,35 @@
+<?php
+// Heading
+$_['heading_title']     = 'Marketing Tracking';
+
+// Text
+$_['text_success']      = 'Success: You have modified <b>Marketing Tracking</b> !';
+$_['text_list']         = 'Marketing Tracking List';
+$_['text_insert']       = 'Add Marketing Tracking';
+$_['text_update']       = 'Edit Marketing Tracking';
+
+// Column
+$_['column_name']       = 'Campaign Name';
+$_['column_code']       = 'Code';
+$_['column_clicks']     = 'Clicks';
+$_['column_orders']     = 'Orders';
+$_['column_date_added'] = 'Date Added';
+$_['column_action']     = 'Action';
+
+// Entry
+$_['entry_name']        = 'Campaign Name';
+$_['entry_description'] = 'Campaign Description';
+$_['entry_code']        = 'Tracking Code';
+$_['entry_example']     = 'Examples';
+$_['entry_date_added']  = 'Date Added';
+
+// Help
+$_['help_code']         = 'The tracking code that will be used to track marketing campaigns.';
+$_['help_example']      = 'So the system can track referrals, you need to add the tracking code to the end of the URL linking to your site.';
+
+// Error
+$_['error_warning']     = 'Warning: Please check the form carefully for errors!';
+$_['error_permission']  = 'Warning: You do not have permission to modify <b>Marketing Tracking</b> !';
+$_['error_name']        = 'Campaign must be between 1 and 32 characters!';
+$_['error_code']        = 'Tracking Code required!';
+?>

--- a/upload/admin/language/english/report/affiliate.php
+++ b/upload/admin/language/english/report/affiliate.php
@@ -1,0 +1,20 @@
+<?php
+// Heading
+$_['heading_title']     = 'Affiliate Commission Report';
+
+// Text
+$_['text_list']         = 'Affiliate Commission List';
+
+// Column
+$_['column_affiliate']  = 'Affiliate Name';
+$_['column_email']      = 'E-Mail';
+$_['column_status']     = 'Status';
+$_['column_commission'] = 'Commission';
+$_['column_orders']     = 'No. Orders';
+$_['column_total']      = 'Total';
+$_['column_action']     = 'Action';
+
+// Entry
+$_['entry_date_start']  = 'Date Start';
+$_['entry_date_end']    = 'Date End';
+?>

--- a/upload/admin/language/english/report/affiliate_activity.php
+++ b/upload/admin/language/english/report/affiliate_activity.php
@@ -1,0 +1,25 @@
+<?php
+// Heading
+$_['heading_title']     = 'Affiliate Activity Report';
+
+// Text
+$_['text_list']         = 'Affiliate Activity List';
+$_['text_edit']         = '<a href="affiliate_id=%d">%s</a> updated their account details.';
+$_['text_forgotten']    = '<a href="affiliate_id=%d">%s</a> requested a new password.';
+$_['text_login']        = '<a href="affiliate_id=%d">%s</a> logged in.';
+$_['text_password']     = '<a href="affiliate_id=%d">%s</a> updated their account password.';
+$_['text_payment']      = '<a href="affiliate_id=%d">%s</a> updated their payment details.';
+$_['text_register']     = '<a href="affiliate_id=%d">%s</a> registered for a new account.';
+
+// Column
+$_['column_affiliate']  = 'Affiliate';
+$_['column_comment']    = 'Comment';
+$_['column_ip']         = 'IP';
+$_['column_date_added'] = 'Date Added';
+
+// Entry
+$_['entry_affiliate']   = 'Affiliate';
+$_['entry_ip']          = 'IP';
+$_['entry_date_start']  = 'Date Start';
+$_['entry_date_end']    = 'Date End';
+?>

--- a/upload/admin/language/english/report/marketing.php
+++ b/upload/admin/language/english/report/marketing.php
@@ -1,0 +1,20 @@
+<?php
+// Heading
+$_['heading_title']    = 'Marketing Report';
+
+// Text
+$_['text_list']         = 'Marketing List';
+$_['text_all_status']   = 'All Statuses';
+
+// Column
+$_['column_campaign']  = 'Campaign Name';
+$_['column_code']      = 'Code';
+$_['column_clicks']    = 'Clicks';
+$_['column_orders']    = 'No. Orders';
+$_['column_total']     = 'Total';
+
+// Entry
+$_['entry_date_start'] = 'Date Start';
+$_['entry_date_end']   = 'Date End';
+$_['entry_status']     = 'Order Status';
+?>

--- a/upload/admin/model/marketing/affiliate.php
+++ b/upload/admin/model/marketing/affiliate.php
@@ -1,0 +1,300 @@
+<?php
+class ModelMarketingAffiliate extends Model {
+	public function addAffiliate($data) {
+		$this->db->query("INSERT INTO " . DB_PREFIX . "affiliate SET firstname = '" . $this->db->escape($data['firstname']) . "', lastname = '" . $this->db->escape($data['lastname']) . "', email = '" . $this->db->escape($data['email']) . "', telephone = '" . $this->db->escape($data['telephone']) . "', fax = '" . $this->db->escape($data['fax']) . "', salt = '" . $this->db->escape($salt = substr(hash_rand('md5'), 0, 9)) . "', password = '" . $this->db->escape(sha1($salt . sha1($salt . sha1($data['password'])))) . "', company = '" . $this->db->escape($data['company']) . "', website = '" . $this->db->escape($data['website']) . "', address_1 = '" . $this->db->escape($data['address_1']) . "', address_2 = '" . $this->db->escape($data['address_2']) . "', city = '" . $this->db->escape($data['city']) . "', postcode = '" . $this->db->escape($data['postcode']) . "', country_id = '" . (int)$data['country_id'] . "', zone_id = '" . (int)$data['zone_id'] . "', code = '" . $this->db->escape($data['code']) . "', commission = '" . (float)$data['commission'] . "', tax = '" . $this->db->escape($data['tax']) . "', payment = '" . $this->db->escape($data['payment']) . "', cheque = '" . $this->db->escape($data['cheque']) . "', paypal = '" . $this->db->escape($data['paypal']) . "', bank_name = '" . $this->db->escape($data['bank_name']) . "', bank_branch_number = '" . $this->db->escape($data['bank_branch_number']) . "', bank_swift_code = '" . $this->db->escape($data['bank_swift_code']) . "', bank_account_name = '" . $this->db->escape($data['bank_account_name']) . "', bank_account_number = '" . $this->db->escape($data['bank_account_number']) . "', status = '" . (int)$data['status'] . "', date_added = NOW()");
+
+		return $this->db->getLastId();
+	}
+
+	public function editAffiliate($affiliate_id, $data) {
+		$this->db->query("UPDATE " . DB_PREFIX . "affiliate SET firstname = '" . $this->db->escape($data['firstname']) . "', lastname = '" . $this->db->escape($data['lastname']) . "', email = '" . $this->db->escape($data['email']) . "', telephone = '" . $this->db->escape($data['telephone']) . "', fax = '" . $this->db->escape($data['fax']) . "', company = '" . $this->db->escape($data['company']) . "', website = '" . $this->db->escape($data['website']) . "', address_1 = '" . $this->db->escape($data['address_1']) . "', address_2 = '" . $this->db->escape($data['address_2']) . "', city = '" . $this->db->escape($data['city']) . "', postcode = '" . $this->db->escape($data['postcode']) . "', country_id = '" . (int)$data['country_id'] . "', zone_id = '" . (int)$data['zone_id'] . "', code = '" . $this->db->escape($data['code']) . "', commission = '" . (float)$data['commission'] . "', tax = '" . $this->db->escape($data['tax']) . "', payment = '" . $this->db->escape($data['payment']) . "', cheque = '" . $this->db->escape($data['cheque']) . "', paypal = '" . $this->db->escape($data['paypal']) . "', bank_name = '" . $this->db->escape($data['bank_name']) . "', bank_branch_number = '" . $this->db->escape($data['bank_branch_number']) . "', bank_swift_code = '" . $this->db->escape($data['bank_swift_code']) . "', bank_account_name = '" . $this->db->escape($data['bank_account_name']) . "', bank_account_number = '" . $this->db->escape($data['bank_account_number']) . "', status = '" . (int)$data['status'] . "' WHERE affiliate_id = '" . (int)$affiliate_id . "'");
+
+		if ($data['password']) {
+			$this->db->query("UPDATE " . DB_PREFIX . "affiliate SET salt = '" . $this->db->escape($salt = token(9)) . "', password = '" . $this->db->escape(sha1($salt . sha1($salt . sha1($data['password'])))) . "' WHERE affiliate_id = '" . (int)$affiliate_id . "'");
+		}
+	}
+
+	public function deleteAffiliate($affiliate_id) {
+		$this->db->query("DELETE FROM " . DB_PREFIX . "affiliate WHERE affiliate_id = '" . (int)$affiliate_id . "'");
+		$this->db->query("DELETE FROM " . DB_PREFIX . "affiliate_activity WHERE affiliate_id = '" . (int)$affiliate_id . "'");
+		$this->db->query("DELETE FROM " . DB_PREFIX . "affiliate_transaction WHERE affiliate_id = '" . (int)$affiliate_id . "'");
+	}
+
+	public function getAffiliate($affiliate_id) {
+		$query = $this->db->query("SELECT DISTINCT * FROM " . DB_PREFIX . "affiliate WHERE affiliate_id = '" . (int)$affiliate_id . "'");
+
+		return $query->row;
+	}
+
+	public function getAffiliateByEmail($email) {
+		$query = $this->db->query("SELECT DISTINCT * FROM " . DB_PREFIX . "affiliate WHERE LCASE(email) = '" . $this->db->escape(utf8_strtolower($email)) . "'");
+
+		return $query->row;
+	}
+
+	public function getAffiliates($data = array()) {
+		$sql = "SELECT *, CONCAT(a.firstname, ' ', a.lastname) AS name, (SELECT SUM(at.amount) FROM " . DB_PREFIX . "affiliate_transaction at WHERE at.affiliate_id = a.affiliate_id GROUP BY at.affiliate_id) AS balance FROM " . DB_PREFIX . "affiliate a";
+
+		$implode = array();
+
+		if (!empty($data['filter_name'])) {
+			$implode[] = "CONCAT(a.firstname, ' ', a.lastname) LIKE '" . $this->db->escape($data['filter_name']) . "%'";
+		}
+
+		if (!empty($data['filter_email'])) {
+			$implode[] = "LCASE(a.email) = '" . $this->db->escape(utf8_strtolower($data['filter_email'])) . "'";
+		}
+
+		if (!empty($data['filter_code'])) {
+			$implode[] = "a.code = '" . $this->db->escape($data['filter_code']) . "'";
+		}
+
+		if (isset($data['filter_approved']) && !is_null($data['filter_approved'])) {
+			$implode[] = "a.approved = '" . (int)$data['filter_approved'] . "'";
+		}
+
+		if (!empty($data['filter_date_added'])) {
+			$implode[] = "DATE(a.date_added) = DATE('" . $this->db->escape($data['filter_date_added']) . "')";
+		}
+
+		if (isset($data['filter_status']) && !is_null($data['filter_status'])) {
+			$implode[] = "a.status = '" . (int)$data['filter_status'] . "'";
+		}
+
+		if ($implode) {
+			$sql .= " WHERE " . implode(" AND ", $implode);
+		}
+
+		$sort_data = array(
+			'name',
+			'a.email',
+			'a.code',
+			'a.approved',
+			'a.date_added',
+			'a.status'
+		);
+
+		if (isset($data['sort']) && in_array($data['sort'], $sort_data)) {
+			$sql .= " ORDER BY " . $data['sort'];
+		} else {
+			$sql .= " ORDER BY name";
+		}
+
+		if (isset($data['order']) && ($data['order'] == 'DESC')) {
+			$sql .= " DESC";
+		} else {
+			$sql .= " ASC";
+		}
+
+		if (isset($data['start']) || isset($data['limit'])) {
+			if ($data['start'] < 0) {
+				$data['start'] = 0;
+			}
+
+			if ($data['limit'] < 1) {
+				$data['limit'] = 20;
+			}
+
+			$sql .= " LIMIT " . (int)$data['start'] . "," . (int)$data['limit'];
+		}
+
+		$query = $this->db->query($sql);
+
+		return $query->rows;
+	}
+
+	public function approve($affiliate_id) {
+		$affiliate_info = $this->getAffiliate($affiliate_id);
+
+		if ($affiliate_info) {
+			$this->db->query("UPDATE " . DB_PREFIX . "affiliate SET approved = '1' WHERE affiliate_id = '" . (int)$affiliate_id . "'");
+
+			$this->load->language('mail/affiliate');
+
+			$message  = sprintf($this->language->get('text_approve_welcome'), html_entity_decode($this->config->get('config_name'), ENT_QUOTES, 'UTF-8')) . "\n\n";
+			$message .= $this->language->get('text_approve_login') . "\n";
+			$message .= HTTP_CATALOG . 'index.php?route=affiliate/login' . "\n\n";
+			$message .= $this->language->get('text_approve_services') . "\n\n";
+			$message .= $this->language->get('text_approve_thanks') . "\n";
+			$message .= html_entity_decode($this->config->get('config_name'), ENT_QUOTES, 'UTF-8');
+
+			// HTML Mail
+			$subject = html_entity_decode(sprintf($this->language->get('text_approve_subject'), $this->config->get('config_name')), ENT_QUOTES, 'UTF-8');
+
+			$template = new Template();
+
+			$template->data['title'] = $subject;
+			$template->data['logo'] = HTTP_CATALOG . 'image/' . $this->config->get('config_logo');
+			$template->data['store_name'] = $this->config->get('config_name');
+			$template->data['store_url'] = HTTP_CATALOG;
+			$template->data['message'] = nl2br($message);
+
+			$html = $template->fetch('mail/default.tpl');
+
+			$mail = new Mail();
+			$mail->protocol = $this->config->get('config_mail_protocol');
+			$mail->parameter = $this->config->get('config_mail_parameter');
+			$mail->hostname = $this->config->get('config_smtp_host');
+			$mail->username = html_entity_decode($this->config->get('config_smtp_username'), ENT_QUOTES, 'UTF-8');
+			$mail->password = html_entity_decode($this->config->get('config_smtp_password'), ENT_QUOTES, 'UTF-8');
+			$mail->port = $this->config->get('config_smtp_port');
+			$mail->timeout = $this->config->get('config_smtp_timeout');
+			$mail->setTo($affiliate_info['email']);
+			$mail->setFrom($this->config->get('config_email'));
+			$mail->setSender(html_entity_decode($this->config->get('config_name'), ENT_QUOTES, 'UTF-8'));
+			$mail->setSubject($subject);
+			$mail->setHtml($html);
+			$mail->send();
+		}
+	}
+
+	public function getAffiliatesByNewsletter() {
+		$query = $this->db->query("SELECT * FROM " . DB_PREFIX . "affiliate WHERE newsletter = '1' ORDER BY firstname, lastname, email");
+
+		return $query->rows;
+	}
+
+	public function getTotalAffiliates($data = array()) {
+		$sql = "SELECT COUNT(*) AS total FROM " . DB_PREFIX . "affiliate";
+
+		$implode = array();
+
+		if (!empty($data['filter_name'])) {
+			$implode[] = "CONCAT(firstname, ' ', lastname) LIKE '%" . $this->db->escape($data['filter_name']) . "%'";
+		}
+
+		if (!empty($data['filter_email'])) {
+			$implode[] = "LCASE(email) = '" . $this->db->escape(utf8_strtolower($data['filter_email'])) . "'";
+		}
+
+		if (isset($data['filter_approved']) && !is_null($data['filter_approved'])) {
+			$implode[] = "approved = '" . (int)$data['filter_approved'] . "'";
+		}
+
+		if (!empty($data['filter_date_added'])) {
+			$implode[] = "DATE(date_added) = DATE('" . $this->db->escape($data['filter_date_added']) . "')";
+		}
+
+		if (isset($data['filter_status']) && !is_null($data['filter_status'])) {
+			$implode[] = "status = '" . (int)$data['filter_status'] . "'";
+		}
+
+		if ($implode) {
+			$sql .= " WHERE " . implode(" AND ", $implode);
+		}
+
+		$query = $this->db->query($sql);
+
+		return $query->row['total'];
+	}
+
+	public function getTotalAffiliatesAwaitingApproval() {
+		$query = $this->db->query("SELECT COUNT(*) AS total FROM " . DB_PREFIX . "affiliate WHERE status = '0' OR approved = '0'");
+
+		return $query->row['total'];
+	}
+
+	public function getTotalAffiliatesByCountryId($country_id) {
+		$query = $this->db->query("SELECT COUNT(*) AS total FROM " . DB_PREFIX . "affiliate WHERE country_id = '" . (int)$country_id . "'");
+
+		return $query->row['total'];
+	}
+
+	public function getTotalAffiliatesByZoneId($zone_id) {
+		$query = $this->db->query("SELECT COUNT(*) AS total FROM " . DB_PREFIX . "affiliate WHERE zone_id = '" . (int)$zone_id . "'");
+
+		return $query->row['total'];
+	}
+
+	public function addTransaction($affiliate_id, $description = '', $amount = '', $order_id = 0) {
+		$affiliate_info = $this->getAffiliate($affiliate_id);
+
+		if ($affiliate_info) {
+			$this->db->query("INSERT INTO " . DB_PREFIX . "affiliate_transaction SET affiliate_id = '" . (int)$affiliate_id . "', order_id = '" . (float)$order_id . "', description = '" . $this->db->escape($description) . "', amount = '" . (float)$amount . "', date_added = NOW()");
+
+			$affiliate_transaction_id = $this->db->getLastId();
+
+			$this->load->language('mail/affiliate');
+
+			$message  = sprintf($this->language->get('text_transaction_received'), $this->currency->format($amount, $this->config->get('config_currency'))) . "\n\n";
+			$message .= sprintf($this->language->get('text_transaction_total'), $this->currency->format($this->getTransactionTotal($affiliate_id), $this->config->get('config_currency')));
+
+			// HTML Mail
+			$subject = html_entity_decode(sprintf($this->language->get('text_transaction_subject'), $this->config->get('config_name')), ENT_QUOTES, 'UTF-8');
+
+			$template = new Template();
+
+			$template->data['title'] = $subject;
+			$template->data['logo'] = HTTP_CATALOG . 'image/' . $this->config->get('config_logo');
+			$template->data['store_name'] = $this->config->get('config_name');
+			$template->data['store_url'] = HTTP_CATALOG;
+			$template->data['message'] = nl2br($message);
+
+			$html = $template->fetch('mail/default.tpl');
+
+			$mail = new Mail();
+			$mail->protocol = $this->config->get('config_mail_protocol');
+			$mail->parameter = $this->config->get('config_mail_parameter');
+			$mail->hostname = $this->config->get('config_smtp_host');
+			$mail->username = html_entity_decode($this->config->get('config_smtp_username'), ENT_QUOTES, 'UTF-8');
+			$mail->password = html_entity_decode($this->config->get('config_smtp_password'), ENT_QUOTES, 'UTF-8');
+			$mail->port = $this->config->get('config_smtp_port');
+			$mail->timeout = $this->config->get('config_smtp_timeout');
+			$mail->setTo($affiliate_info['email']);
+			$mail->setFrom($this->config->get('config_email'));
+			$mail->setSender(html_entity_decode($this->config->get('config_name'), ENT_QUOTES, 'UTF-8'));
+			$mail->setSubject($subject);
+			$mail->setHtml($html);
+			$mail->send();
+
+			return $affiliate_transaction_id;
+		}
+	}
+
+	public function deleteTransaction($order_id) {
+		$this->db->query("DELETE FROM " . DB_PREFIX . "affiliate_transaction WHERE order_id = '" . (int)$order_id . "'");
+	}
+
+	public function getTransactions($affiliate_id, $start = 0, $limit = 10) {
+		if ($start < 0) {
+			$start = 0;
+		}
+
+		if ($limit < 1) {
+			$limit = 10;
+		}
+
+		$query = $this->db->query("SELECT * FROM " . DB_PREFIX . "affiliate_transaction WHERE affiliate_id = '" . (int)$affiliate_id . "' ORDER BY date_added DESC LIMIT " . (int)$start . "," . (int)$limit);
+
+		return $query->rows;
+	}
+
+	public function getTotalTransactions($affiliate_id) {
+		$query = $this->db->query("SELECT COUNT(*) AS total  FROM " . DB_PREFIX . "affiliate_transaction WHERE affiliate_id = '" . (int)$affiliate_id . "'");
+
+		return $query->row['total'];
+	}
+
+	public function getTransactionTotal($affiliate_id) {
+		$query = $this->db->query("SELECT SUM(amount) AS total FROM " . DB_PREFIX . "affiliate_transaction WHERE affiliate_id = '" . (int)$affiliate_id . "'");
+
+		return $query->row['total'];
+	}
+
+	public function getTotalTransactionsByOrderId($order_id) {
+		$query = $this->db->query("SELECT COUNT(*) AS total FROM " . DB_PREFIX . "affiliate_transaction WHERE order_id = '" . (int)$order_id . "'");
+
+		return $query->row['total'];
+	}
+
+	public function getTotalLoginAttempts($email) {
+		$query = $this->db->query("SELECT * FROM `" . DB_PREFIX . "affiliate_login` WHERE `email` = '" . $this->db->escape($email) . "'");
+
+		return $query->row;
+	}
+
+	public function deleteLoginAttempts($email) {
+		$this->db->query("DELETE FROM `" . DB_PREFIX . "affiliate_login` WHERE `email` = '" . $this->db->escape($email) . "'");
+	}
+}
+?>

--- a/upload/admin/model/marketing/coupon.php
+++ b/upload/admin/model/marketing/coupon.php
@@ -1,0 +1,154 @@
+<?php
+class ModelMarketingCoupon extends Model {
+	public function addCoupon($data) {
+		$this->db->query("INSERT INTO " . DB_PREFIX . "coupon SET name = '" . $this->db->escape($data['name']) . "', code = '" . $this->db->escape($data['code']) . "', discount = '" . (float)$data['discount'] . "', type = '" . $this->db->escape($data['type']) . "', total = '" . (float)$data['total'] . "', logged = '" . (int)$data['logged'] . "', shipping = '" . (int)$data['shipping'] . "', date_start = '" . $this->db->escape($data['date_start']) . "', date_end = '" . $this->db->escape($data['date_end']) . "', uses_total = '" . (int)$data['uses_total'] . "', uses_customer = '" . (int)$data['uses_customer'] . "', status = '" . (int)$data['status'] . "', date_added = NOW()");
+
+		$coupon_id = $this->db->getLastId();
+
+		if (isset($data['coupon_product'])) {
+			foreach ($data['coupon_product'] as $product_id) {
+				$this->db->query("INSERT INTO " . DB_PREFIX . "coupon_product SET coupon_id = '" . (int)$coupon_id . "', product_id = '" . (int)$product_id . "'");
+			}
+		}
+
+		if (isset($data['coupon_category'])) {
+			foreach ($data['coupon_category'] as $category_id) {
+				$this->db->query("INSERT INTO " . DB_PREFIX . "coupon_category SET coupon_id = '" . (int)$coupon_id . "', category_id = '" . (int)$category_id . "'");
+			}
+		}
+
+		return $coupon_id;
+	}
+
+	public function editCoupon($coupon_id, $data) {
+		$this->db->query("UPDATE " . DB_PREFIX . "coupon SET name = '" . $this->db->escape($data['name']) . "', code = '" . $this->db->escape($data['code']) . "', discount = '" . (float)$data['discount'] . "', type = '" . $this->db->escape($data['type']) . "', total = '" . (float)$data['total'] . "', logged = '" . (int)$data['logged'] . "', shipping = '" . (int)$data['shipping'] . "', date_start = '" . $this->db->escape($data['date_start']) . "', date_end = '" . $this->db->escape($data['date_end']) . "', uses_total = '" . (int)$data['uses_total'] . "', uses_customer = '" . (int)$data['uses_customer'] . "', status = '" . (int)$data['status'] . "' WHERE coupon_id = '" . (int)$coupon_id . "'");
+
+		$this->db->query("DELETE FROM " . DB_PREFIX . "coupon_product WHERE coupon_id = '" . (int)$coupon_id . "'");
+
+		if (isset($data['coupon_product'])) {
+			foreach ($data['coupon_product'] as $product_id) {
+				$this->db->query("INSERT INTO " . DB_PREFIX . "coupon_product SET coupon_id = '" . (int)$coupon_id . "', product_id = '" . (int)$product_id . "'");
+			}
+		}
+
+		$this->db->query("DELETE FROM " . DB_PREFIX . "coupon_category WHERE coupon_id = '" . (int)$coupon_id . "'");
+
+		if (isset($data['coupon_category'])) {
+			foreach ($data['coupon_category'] as $category_id) {
+				$this->db->query("INSERT INTO " . DB_PREFIX . "coupon_category SET coupon_id = '" . (int)$coupon_id . "', category_id = '" . (int)$category_id . "'");
+			}
+		}
+	}
+
+	public function deleteCoupon($coupon_id) {
+		$this->db->query("DELETE FROM " . DB_PREFIX . "coupon WHERE coupon_id = '" . (int)$coupon_id . "'");
+		$this->db->query("DELETE FROM " . DB_PREFIX . "coupon_product WHERE coupon_id = '" . (int)$coupon_id . "'");
+		$this->db->query("DELETE FROM " . DB_PREFIX . "coupon_category WHERE coupon_id = '" . (int)$coupon_id . "'");
+		$this->db->query("DELETE FROM " . DB_PREFIX . "coupon_history WHERE coupon_id = '" . (int)$coupon_id . "'");
+	}
+
+	public function getCoupon($coupon_id) {
+		$query = $this->db->query("SELECT DISTINCT * FROM " . DB_PREFIX . "coupon WHERE coupon_id = '" . (int)$coupon_id . "'");
+
+		return $query->row;
+	}
+
+	public function getCouponByCode($code) {
+		$query = $this->db->query("SELECT DISTINCT * FROM " . DB_PREFIX . "coupon WHERE code = '" . $this->db->escape($code) . "'");
+
+		return $query->row;
+	}
+
+	public function getCoupons($data = array()) {
+		$sql = "SELECT coupon_id, name, code, type, discount, date_start, date_end, status FROM " . DB_PREFIX . "coupon";
+
+		$sort_data = array(
+			'name',
+			'code',
+			'type',
+			'discount',
+			'date_start',
+			'date_end',
+			'status'
+		);
+
+		if (isset($data['sort']) && in_array($data['sort'], $sort_data)) {
+			$sql .= " ORDER BY " . $data['sort'];
+		} else {
+			$sql .= " ORDER BY name";
+		}
+
+		if (isset($data['order']) && ($data['order'] == 'DESC')) {
+			$sql .= " DESC";
+		} else {
+			$sql .= " ASC";
+		}
+
+		if (isset($data['start']) || isset($data['limit'])) {
+			if ($data['start'] < 0) {
+				$data['start'] = 0;
+			}
+
+			if ($data['limit'] < 1) {
+				$data['limit'] = 20;
+			}
+
+			$sql .= " LIMIT " . (int)$data['start'] . "," . (int)$data['limit'];
+		}
+
+		$query = $this->db->query($sql);
+
+		return $query->rows;
+	}
+
+	public function getCouponProducts($coupon_id) {
+		$coupon_product_data = array();
+
+		$query = $this->db->query("SELECT * FROM " . DB_PREFIX . "coupon_product WHERE coupon_id = '" . (int)$coupon_id . "'");
+
+		foreach ($query->rows as $result) {
+			$coupon_product_data[] = $result['product_id'];
+		}
+
+		return $coupon_product_data;
+	}
+
+	public function getCouponCategories($coupon_id) {
+		$coupon_category_data = array();
+
+		$query = $this->db->query("SELECT * FROM " . DB_PREFIX . "coupon_category WHERE coupon_id = '" . (int)$coupon_id . "'");
+
+		foreach ($query->rows as $result) {
+			$coupon_category_data[] = $result['category_id'];
+		}
+
+		return $coupon_category_data;
+	}
+
+	public function getTotalCoupons() {
+		$query = $this->db->query("SELECT COUNT(*) AS total FROM " . DB_PREFIX . "coupon");
+
+		return $query->row['total'];
+	}
+
+	public function getCouponHistories($coupon_id, $start = 0, $limit = 10) {
+		if ($start < 0) {
+			$start = 0;
+		}
+
+		if ($limit < 1) {
+			$limit = 10;
+		}
+
+		$query = $this->db->query("SELECT ch.order_id, CONCAT(c.firstname, ' ', c.lastname) AS customer, ch.amount, ch.date_added FROM " . DB_PREFIX . "coupon_history ch LEFT JOIN " . DB_PREFIX . "customer c ON (ch.customer_id = c.customer_id) WHERE ch.coupon_id = '" . (int)$coupon_id . "' ORDER BY ch.date_added ASC LIMIT " . (int)$start . "," . (int)$limit);
+
+		return $query->rows;
+	}
+
+	public function getTotalCouponHistories($coupon_id) {
+		$query = $this->db->query("SELECT COUNT(*) AS total FROM " . DB_PREFIX . "coupon_history WHERE coupon_id = '" . (int)$coupon_id . "'");
+
+		return $query->row['total'];
+	}
+}
+?>

--- a/upload/admin/model/marketing/marketing.php
+++ b/upload/admin/model/marketing/marketing.php
@@ -1,0 +1,108 @@
+<?php
+class ModelMarketingMarketing extends Model {
+	public function addMarketing($data) {
+		$this->db->query("INSERT INTO " . DB_PREFIX . "marketing SET name = '" . $this->db->escape($data['name']) . "', description = '" . $this->db->escape($data['description']) . "', code = '" . $this->db->escape($data['code']) . "', date_added = NOW()");
+
+		return $this->db->getLastId();
+	}
+
+	public function editMarketing($marketing_id, $data) {
+		$this->db->query("UPDATE " . DB_PREFIX . "marketing SET name = '" . $this->db->escape($data['name']) . "', description = '" . $this->db->escape($data['description']) . "', code = '" . $this->db->escape($data['code']) . "' WHERE marketing_id = '" . (int)$marketing_id . "'");
+	}
+
+	public function deleteMarketing($marketing_id) {
+		$this->db->query("DELETE FROM " . DB_PREFIX . "marketing WHERE marketing_id = '" . (int)$marketing_id . "'");
+	}
+
+	public function getMarketing($marketing_id) {
+		$query = $this->db->query("SELECT DISTINCT * FROM " . DB_PREFIX . "marketing WHERE marketing_id = '" . (int)$marketing_id . "'");
+
+		return $query->row;
+	}
+
+	public function getMarketings($data = array()) {
+		// OC2.x has multiple complete statuses versus only one here.
+		$complete_status_id = $this->config->get('config_complete_status_id');
+
+		$sql = "SELECT *, (SELECT COUNT(*) FROM `" . DB_PREFIX . "order` o WHERE o.order_status_id = '" . (int)$complete_status_id . "' AND o.marketing_id = m.marketing_id) AS orders FROM " . DB_PREFIX . "marketing m";
+
+		$implode = array();
+
+		if (!empty($data['filter_name'])) {
+			$implode[] = "m.name LIKE '" . $this->db->escape($data['filter_name']) . "%'";
+		}
+
+		if (!empty($data['filter_code'])) {
+			$implode[] = "m.code = '" . $this->db->escape($data['filter_code']) . "'";
+		}
+
+		if (!empty($data['filter_date_added'])) {
+			$implode[] = "DATE(m.date_added) = DATE('" . $this->db->escape($data['filter_date_added']) . "')";
+		}
+
+		if ($implode) {
+			$sql .= " WHERE " . implode(" AND ", $implode);
+		}
+
+		$sort_data = array(
+			'm.name',
+			'm.code',
+			'm.date_added'
+		);
+
+		if (isset($data['sort']) && in_array($data['sort'], $sort_data)) {
+			$sql .= " ORDER BY " . $data['sort'];
+		} else {
+			$sql .= " ORDER BY name";
+		}
+
+		if (isset($data['order']) && ($data['order'] == 'DESC')) {
+			$sql .= " DESC";
+		} else {
+			$sql .= " ASC";
+		}
+
+		if (isset($data['start']) || isset($data['limit'])) {
+			if ($data['start'] < 0) {
+				$data['start'] = 0;
+			}
+
+			if ($data['limit'] < 1) {
+				$data['limit'] = 20;
+			}
+
+			$sql .= " LIMIT " . (int)$data['start'] . "," . (int)$data['limit'];
+		}
+
+		$query = $this->db->query($sql);
+
+		return $query->rows;
+	}
+
+	public function getTotalMarketings($data = array()) {
+		$sql = "SELECT COUNT(*) AS total FROM " . DB_PREFIX . "marketing";
+
+		$implode = array();
+
+		if (!empty($data['filter_name'])) {
+			$implode[] = "name LIKE '" . $this->db->escape($data['filter_name']) . "'";
+		}
+
+		if (!empty($data['filter_code'])) {
+			$implode[] = "code = '" . $this->db->escape($data['filter_code']) . "'";
+		}
+
+		if (!empty($data['filter_date_added'])) {
+			$implode[] = "DATE(date_added) = DATE('" . $this->db->escape($data['filter_date_added']) . "')";
+		}
+
+		if ($implode) {
+			$sql .= " WHERE " . implode(" AND ", $implode);
+		}
+
+		$query = $this->db->query($sql);
+
+		return $query->row['total'];
+	}
+}
+?>

--- a/upload/admin/model/report/activity.php
+++ b/upload/admin/model/report/activity.php
@@ -1,0 +1,9 @@
+<?php
+class ModelReportActivity extends Model {
+	public function getActivities() {
+		$query = $this->db->query("SELECT a.key, a.data, a.date_added FROM ((SELECT CONCAT('customer_', ca.key) AS `key`, ca.data, ca.date_added FROM `" . DB_PREFIX . "customer_activity` ca) UNION (SELECT CONCAT('affiliate_', aa.key) AS `key`, aa.data, aa.date_added FROM `" . DB_PREFIX . "affiliate_activity` aa)) a ORDER BY a.date_added DESC LIMIT 0,5");
+
+		return $query->rows;
+	}
+}
+?>

--- a/upload/admin/model/report/marketing.php
+++ b/upload/admin/model/report/marketing.php
@@ -1,0 +1,61 @@
+<?php
+class ModelReportMarketing extends Model {
+	public function getMarketing($data = array()) {
+		$sql = "SELECT m.marketing_id, m.name AS campaign, m.code, m.clicks AS clicks, (SELECT COUNT(DISTINCT order_id) FROM `" . DB_PREFIX . "order` o1 WHERE o1.marketing_id = m.marketing_id";
+
+		if (!empty($data['filter_order_status_id'])) {
+			$sql .= " AND o1.order_status_id = '" . (int)$data['filter_order_status_id'] . "'";
+		} else {
+			$sql .= " AND o1.order_status_id > '0'";
+		}
+
+		if (!empty($data['filter_date_start'])) {
+			$sql .= " AND DATE(o1.date_added) >= '" . $this->db->escape($data['filter_date_start']) . "'";
+		}
+
+		if (!empty($data['filter_date_end'])) {
+			$sql .= " AND DATE(o1.date_added) <= '" . $this->db->escape($data['filter_date_end']) . "'";
+		}
+
+		$sql .= ") AS `orders`, (SELECT SUM(total) FROM `" . DB_PREFIX . "order` o2 WHERE o2.marketing_id = m.marketing_id";
+
+		if (!empty($data['filter_order_status_id'])) {
+			$sql .= " AND o2.order_status_id = '" . (int)$data['filter_order_status_id'] . "'";
+		} else {
+			$sql .= " AND o2.order_status_id > '0'";
+		}
+
+		if (!empty($data['filter_date_start'])) {
+			$sql .= " AND DATE(o2.date_added) >= '" . $this->db->escape($data['filter_date_start']) . "'";
+		}
+
+		if (!empty($data['filter_date_end'])) {
+			$sql .= " AND DATE(o2.date_added) <= '" . $this->db->escape($data['filter_date_end']) . "'";
+		}
+
+		$sql .= " GROUP BY o2.marketing_id) AS `total` FROM `" . DB_PREFIX . "marketing` m ORDER BY m.date_added ASC";
+
+		if (isset($data['start']) || isset($data['limit'])) {
+			if ($data['start'] < 0) {
+				$data['start'] = 0;
+			}
+
+			if ($data['limit'] < 1) {
+				$data['limit'] = 20;
+			}
+
+			$sql .= " LIMIT " . (int)$data['start'] . "," . (int)$data['limit'];
+		}
+
+		$query = $this->db->query($sql);
+
+		return $query->rows;
+	}
+
+	public function getTotalMarketing($data = array()) {
+		$query = $this->db->query("SELECT COUNT(*) AS total FROM `" . DB_PREFIX . "marketing`");
+
+		return $query->row['total'];
+	}
+}
+?>

--- a/upload/admin/view/template/common/header.tpl
+++ b/upload/admin/view/template/common/header.tpl
@@ -190,13 +190,11 @@ $(document).ready(function() {
           <li><a class="arrow"><?php echo $text_marketing; ?></a>
             <ul>
               <li><a href="<?php echo $marketing; ?>"><?php echo $text_marketing; ?></a></li>
-<!-- disconnected
               <?php if ($allow_affiliate) { ?>
               <li><a href="<?php echo $affiliate; ?>"><?php echo $text_affiliate; ?></a></li>
               <?php } ?>
               <li><a href="<?php echo $coupon; ?>"><?php echo $text_coupon; ?></a></li>
               <li><a href="<?php echo $contact; ?>"><?php echo $text_contact; ?></a></li>
-//-->
             </ul>
           </li>
           <?php if ($allow_affiliate) { ?>
@@ -353,12 +351,10 @@ $(document).ready(function() {
           <li><a class="arrow"><?php echo $text_marketing; ?></a>
             <ul>
               <li><a href="<?php echo $report_marketing; ?>"><?php echo $text_marketing; ?></a></li>
-<!-- disconnected
               <?php if ($allow_affiliate) { ?>
               <li><a href="<?php echo $report_affiliate; ?>"><?php echo $text_report_affiliate; ?></a></li>
               <li><a href="<?php echo $report_affiliate_activity; ?>"><?php echo $text_report_affiliate_activity; ?></a></li>
               <?php } ?>
-//-->
             </ul>
           </li>
           <li><a class="arrow"><?php echo $text_affiliate; ?></a>

--- a/upload/admin/view/template/common/header.tpl
+++ b/upload/admin/view/template/common/header.tpl
@@ -187,6 +187,18 @@ $(document).ready(function() {
               <li><a href="<?php echo $supplier_product; ?>"><?php echo $text_supplier_product; ?></a></li>
             </ul>
           </li>
+          <li><a class="arrow"><?php echo $text_marketing; ?></a>
+            <ul>
+              <li><a href="<?php echo $marketing; ?>"><?php echo $text_marketing; ?></a></li>
+<!-- disconnected
+              <?php if ($allow_affiliate) { ?>
+              <li><a href="<?php echo $affiliate; ?>"><?php echo $text_affiliate; ?></a></li>
+              <?php } ?>
+              <li><a href="<?php echo $coupon; ?>"><?php echo $text_coupon; ?></a></li>
+              <li><a href="<?php echo $contact; ?>"><?php echo $text_contact; ?></a></li>
+//-->
+            </ul>
+          </li>
           <?php if ($allow_affiliate) { ?>
           <li><a href="<?php echo $affiliate; ?>"><?php echo $text_affiliate; ?></a></li>
           <?php } ?>
@@ -336,6 +348,17 @@ $(document).ready(function() {
               <li><a href="<?php echo $report_customer_credit; ?>"><?php echo $text_report_customer_credit; ?></a></li>
               <li><a href="<?php echo $report_customer_country; ?>"><?php echo $text_report_customer_country; ?></a></li>
               <li><a href="<?php echo $report_customer_online; ?>"><?php echo $text_report_customer_online; ?></a></li>
+            </ul>
+          </li>
+          <li><a class="arrow"><?php echo $text_marketing; ?></a>
+            <ul>
+              <li><a href="<?php echo $report_marketing; ?>"><?php echo $text_marketing; ?></a></li>
+<!-- disconnected
+              <?php if ($allow_affiliate) { ?>
+              <li><a href="<?php echo $report_affiliate; ?>"><?php echo $text_report_affiliate; ?></a></li>
+              <li><a href="<?php echo $report_affiliate_activity; ?>"><?php echo $text_report_affiliate_activity; ?></a></li>
+              <?php } ?>
+//-->
             </ul>
           </li>
           <li><a class="arrow"><?php echo $text_affiliate; ?></a>

--- a/upload/admin/view/template/marketing/affiliate_form.tpl
+++ b/upload/admin/view/template/marketing/affiliate_form.tpl
@@ -1,0 +1,383 @@
+<?php echo $header; ?>
+<div id="content">
+  <div class="breadcrumb">
+  <?php foreach ($breadcrumbs as $breadcrumb) { ?>
+    <?php echo $breadcrumb['separator']; ?><a href="<?php echo $breadcrumb['href']; ?>"><?php echo $breadcrumb['text']; ?></a>
+  <?php } ?>
+  </div>
+  <?php if ($error_warning) { ?>
+    <div class="warning"><?php echo $error_warning; ?></div>
+  <?php } ?>
+  <?php if ($success) { ?>
+    <div class="success"><?php echo $success; ?></div>
+  <?php } ?>
+  <div class="box">
+    <div class="heading">
+      <h1><img src="view/image/customer.png" alt="" /> <?php echo $affiliate_title; ?></h1>
+      <div class="buttons">
+        <a onclick="$('#form').submit();" class="button-save"><?php echo $button_save; ?></a>
+        <a onclick="apply();" class="button-save"><?php echo $button_apply; ?></a>
+        <a href="<?php echo $cancel; ?>" class="button-cancel"><?php echo $button_cancel; ?></a>
+    </div>
+  </div>
+  <div class="content">
+    <div id="htabs" class="htabs">
+      <a href="#tab-general"><?php echo $tab_general; ?></a> <a href="#tab-payment"><?php echo $tab_payment; ?></a>
+      <?php if ($affiliate_id) { ?>
+        <a href="#tab-transaction"><?php echo $tab_transaction; ?></a>
+      <?php } ?>
+    </div>
+    <form action="<?php echo $action; ?>" method="post" enctype="multipart/form-data" id="form">
+      <div id="tab-general">
+        <h2><?php echo $text_affiliate_detail; ?></h2>
+        <table class="form">
+          <tbody>
+          <tr>
+            <td><span class="required">*</span> <?php echo $entry_firstname; ?></td>
+            <td><?php if ($error_firstname) { ?>
+              <input type="text" name="firstname" value="<?php echo $firstname; ?>" size="30" class="input-error" />
+              <span class="error"><?php echo $error_firstname; ?></span>
+            <?php } else { ?>
+              <input type="text" name="firstname" value="<?php echo $firstname; ?>" size="30" />
+            <?php } ?></td>
+          </tr>
+          <tr>
+            <td><span class="required">*</span> <?php echo $entry_lastname; ?></td>
+            <td><?php if ($error_lastname) { ?>
+              <input type="text" name="lastname" value="<?php echo $lastname; ?>" size="30" class="input-error" />
+              <span class="error"><?php echo $error_lastname; ?></span>
+            <?php } else { ?>
+              <input type="text" name="lastname" value="<?php echo $lastname; ?>" size="30" />
+            <?php } ?></td>
+          </tr>
+          <tr>
+            <td><span class="required">*</span> <?php echo $entry_email; ?></td>
+            <td><?php if ($error_email) { ?>
+              <input type="text" name="email" value="<?php echo $email; ?>" size="40" class="input-error" />
+              <span class="error"><?php echo $error_email; ?></span>
+            <?php } else { ?>
+              <input type="text" name="email" value="<?php echo $email; ?>" size="40" />
+            <?php } ?></td>
+          </tr>
+          <tr>
+            <td><span class="required">*</span> <?php echo $entry_telephone; ?></td>
+            <td><?php if ($error_telephone) { ?>
+              <input type="text" name="telephone" value="<?php echo $telephone; ?>" class="input-error" />
+              <span class="error"><?php echo $error_telephone; ?></span>
+            <?php } else { ?>
+              <input type="text" name="telephone" value="<?php echo $telephone; ?>" />
+            <?php } ?></td>
+          </tr>
+          <?php if ($show_fax) { ?>
+          <tr>
+            <td><?php echo $entry_fax; ?></td>
+            <td><input type="text" name="fax" value="<?php echo $fax; ?>" /></td>
+          </tr>
+          <?php } ?>
+          <tr>
+            <td><span class="required">*</span> <?php echo $entry_code; ?></td>
+            <td><input type="code" name="code" value="<?php echo $code; ?>" />
+            <?php if ($error_code) { ?>
+              <span class="error"><?php echo $error_code; ?></span>
+            <?php } ?></td>
+          </tr>
+          <tr>
+            <td><?php echo $entry_password; ?></td>
+            <td><?php if ($error_password) { ?>
+              <input type="password" name="password" value="<?php echo $password; ?>" class="input-error" />
+              <span class="error"><?php echo $error_password; ?></span>
+            <?php } else { ?>
+              <input type="password" name="password" value="<?php echo $password; ?>" />
+            <?php } ?></td>
+          </tr>
+          <tr>
+            <td><?php echo $entry_confirm; ?></td>
+            <td><?php if ($error_confirm) { ?>
+              <input type="password" name="confirm" value="<?php echo $confirm; ?>" class="input-error" />
+              <span class="error"><?php echo $error_confirm; ?></span>
+            <?php } else { ?>
+              <input type="password" name="confirm" value="<?php echo $confirm; ?>" />
+            <?php } ?></td>
+          </tr>
+          <tr>
+            <td><?php echo $entry_status; ?></td>
+            <td><select name="status">
+            <?php if ($status) { ?>
+              <option value="1" selected="selected"><?php echo $text_enabled; ?></option>
+              <option value="0"><?php echo $text_disabled; ?></option>
+            <?php } else { ?>
+              <option value="1"><?php echo $text_enabled; ?></option>
+              <option value="0" selected="selected"><?php echo $text_disabled; ?></option>
+            <?php } ?>
+            </select></td>
+          </tr>
+          </tbody>
+        </table>
+        <h2><?php echo $text_affiliate_address; ?></h2>
+        <table class="form">
+          <tbody>
+          <tr>
+            <td><?php echo $entry_company; ?></td>
+            <td><input type="text" name="company" value="<?php echo $company; ?>" size="40" /></td>
+          </tr>
+          <tr>
+            <td><?php echo $entry_website; ?></td>
+            <td><input type="text" name="website" value="<?php echo $website; ?>" size="40" /></td>
+          </tr>
+          <tr>
+            <td><span class="required">*</span> <?php echo $entry_address_1; ?></td>
+            <td><?php if ($error_address_1) { ?>
+              <input type="text" name="address_1" value="<?php echo $address_1; ?>" size="40" class="input-error" />
+              <span class="error"><?php echo $error_address_1; ?></span>
+            <?php } else { ?>
+              <input type="text" name="address_1" value="<?php echo $address_1; ?>" size="40" />
+            <?php } ?></td>
+          </tr>
+          <tr>
+            <td><?php echo $entry_address_2; ?></td>
+            <td><input type="text" name="address_2" value="<?php echo $address_2; ?>" size="40" /></td>
+          </tr>
+          <tr>
+            <td><span class="required">*</span> <?php echo $entry_city; ?></td>
+            <td><?php if ($error_city) { ?>
+              <input type="text" name="city" value="<?php echo $city; ?>" size="40" class="input-error" />
+              <span class="error"><?php echo $error_city ?></span>
+            <?php } else { ?>
+              <input type="text" name="city" value="<?php echo $city; ?>" size="40" />
+            <?php } ?></td>
+          </tr>
+          <tr>
+            <td><span id="postcode-required" class="required">*</span> <?php echo $entry_postcode; ?></td>
+            <td><?php if ($error_postcode) { ?>
+              <input type="text" name="postcode" value="<?php echo $postcode; ?>" class="input-error" />
+              <span class="error"><?php echo $error_postcode ?></span>
+            <?php } else { ?>
+              <input type="text" name="postcode" value="<?php echo $postcode; ?>" />
+            <?php } ?></td>
+          </tr>
+          <tr>
+            <td><span class="required">*</span> <?php echo $entry_country; ?></td>
+            <td><?php if ($error_country) { ?>
+              <select name="country_id" class="input-error">
+                <option value="false"><?php echo $text_select; ?></option>
+                <?php foreach ($countries as $country) { ?>
+                  <?php if ($country['country_id'] == $country_id) { ?>
+                    <option value="<?php echo $country['country_id']; ?>" selected="selected"> <?php echo $country['name']; ?> </option>
+                  <?php } else { ?>
+                    <option value="<?php echo $country['country_id']; ?>"><?php echo $country['name']; ?></option>
+                  <?php } ?>
+                <?php } ?>
+              </select>
+              <span class="error"><?php echo $error_country; ?></span>
+            <?php } else { ?>
+              <select name="country_id">
+                <option value="false"><?php echo $text_select; ?></option>
+                <?php foreach ($countries as $country) { ?>
+                  <?php if ($country['country_id'] == $country_id) { ?>
+                    <option value="<?php echo $country['country_id']; ?>" selected="selected"> <?php echo $country['name']; ?> </option>
+                  <?php } else { ?>
+                    <option value="<?php echo $country['country_id']; ?>"><?php echo $country['name']; ?></option>
+                  <?php } ?>
+                <?php } ?>
+              </select>
+            <?php } ?></td>
+          </tr>
+          <tr>
+            <td><span class="required">*</span> <?php echo $entry_zone; ?></td>
+            <td><?php if ($error_zone) { ?>
+              <select name="zone_id" class="input-error">
+              </select>
+              <span class="error"><?php echo $error_zone; ?></span>
+            <?php } else { ?>
+              <select name="zone_id">
+              </select>
+            <?php } ?></td>
+          </tr>
+          </tbody>
+        </table>
+      </div>
+      <div id="tab-payment">
+        <table class="form">
+          <tbody>
+          <tr>
+            <td><?php echo $entry_commission; ?></td>
+            <td><input type="text" name="commission" value="<?php echo $commission; ?>" /></td>
+          </tr>
+          <tr>
+            <td><?php echo $entry_tax; ?></td>
+            <td><input type="text" name="tax" value="<?php echo $tax; ?>" /></td>
+          </tr>
+          <tr>
+            <td><?php echo $entry_payment; ?></td>
+            <td><?php if ($payment == 'cheque') { ?>
+              <input type="radio" name="payment" value="cheque" id="cheque" class="checkbox" checked />
+            <?php } else { ?>
+              <input type="radio" name="payment" value="cheque" id="cheque" class="checkbox" />
+            <?php } ?>
+            <label for="cheque"><span></span><?php echo $text_cheque; ?></label> &nbsp;&nbsp;
+            <?php if ($payment == 'paypal') { ?>
+              <input type="radio" name="payment" value="paypal" id="paypal" class="checkbox" checked />
+            <?php } else { ?>
+              <input type="radio" name="payment" value="paypal" id="paypal" class="checkbox" />
+            <?php } ?>
+            <label for="paypal"><span></span><?php echo $text_paypal; ?></label> &nbsp;&nbsp;
+            <?php if ($payment == 'bank') { ?>
+              <input type="radio" name="payment" value="bank" id="bank" class="checkbox" checked />
+            <?php } else { ?>
+              <input type="radio" name="payment" value="bank" id="bank" class="checkbox" />
+            <?php } ?>
+            <label for="bank"><span></span><?php echo $text_bank; ?></label></td>
+          </tr>
+          </tbody>
+          <tbody id="payment-cheque" class="payment">
+          <tr>
+            <td><?php echo $entry_cheque; ?></td>
+            <td><input type="text" name="cheque" value="<?php echo $cheque; ?>" size="40" /></td>
+          </tr>
+          </tbody>
+          <tbody id="payment-paypal" class="payment">
+          <tr>
+            <td><?php echo $entry_paypal; ?></td>
+            <td><input type="text" name="paypal" value="<?php echo $paypal; ?>" size="40" /></td>
+          </tr>
+          </tbody>
+          <tbody id="payment-bank" class="payment">
+          <tr>
+            <td><?php echo $entry_bank_name; ?></td>
+            <td><input type="text" name="bank_name" value="<?php echo $bank_name; ?>" size="40" /></td>
+          </tr>
+          <tr>
+            <td><?php echo $entry_bank_branch_number; ?></td>
+            <td><input type="text" name="bank_branch_number" value="<?php echo $bank_branch_number; ?>" /></td>
+          </tr>
+          <tr>
+            <td><?php echo $entry_bank_swift_code; ?></td>
+            <td><input type="text" name="bank_swift_code" value="<?php echo $bank_swift_code; ?>" /></td>
+          </tr>
+          <tr>
+            <td><span class="required">*</span> <?php echo $entry_bank_account_name; ?></td>
+            <td><input type="text" name="bank_account_name" value="<?php echo $bank_account_name; ?>" /></td>
+          </tr>
+          <tr>
+            <td><span class="required">*</span> <?php echo $entry_bank_account_number; ?></td>
+            <td><input type="text" name="bank_account_number" value="<?php echo $bank_account_number; ?>" /></td>
+          </tr>
+          </tbody>
+        </table>
+      </div>
+      <?php if ($affiliate_id) { ?>
+      <div id="tab-transaction">
+        <table class="form">
+          <tbody>
+          <tr>
+            <td><?php echo $entry_description; ?></td>
+            <td><input type="text" name="description" value="" /></td>
+          </tr>
+          <tr>
+            <td><?php echo $entry_amount; ?></td>
+            <td><input type="text" name="amount" value="" /></td>
+          </tr>
+          <tr>
+            <td colspan="2" style="text-align:right;"><a id="button-reward" onclick="addTransaction();" class="button"><?php echo $button_add_transaction; ?></a></td>
+          </tr>
+          </tbody>
+        </table>
+        <div id="transaction"></div>
+      </div>
+      <?php } ?>
+    </form>
+    </div>
+  </div>
+</div>
+
+<script type="text/javascript"><!--
+$('select[name=\'country_id\']').on('change', function() {
+  $.ajax({
+    url: 'index.php?route=localisation/country/country&token=<?php echo $token; ?>&country_id=' + this.value,
+    dataType: 'json',
+    beforeSend: function() {
+      $('select[name=\'country_id\']').after('<span class="wait">&nbsp;<img src="view/image/loading.gif" alt="" /></span>');
+    },
+    complete: function() {
+      $('.wait').remove();
+    },
+    success: function(json) {
+      if (json['postcode_required'] == '1') {
+        $('#postcode-required').show();
+      } else {
+        $('#postcode-required').hide();
+      }
+
+      html = '<option value=""><?php echo $text_select; ?></option>';
+
+      if (json != '' && json['zone'] != '') {
+        for (i = 0; i < json['zone'].length; i++) {
+          html += '<option value="' + json['zone'][i]['zone_id'] + '"';
+
+          if (json['zone'][i]['zone_id'] == '<?php echo $zone_id; ?>') {
+            html += ' selected="selected"';
+          }
+
+          html += '>' + json['zone'][i]['name'] + '</option>';
+        }
+      } else {
+        html += '<option value="0" selected="selected"><?php echo $text_none; ?></option>';
+      }
+
+      $('select[name=\'zone_id\']').html(html);
+    },
+    error: function(xhr, ajaxOptions, thrownError) {
+      alert(thrownError + "\r\n" + xhr.statusText + "\r\n" + xhr.responseText);
+    }
+  });
+});
+
+$('select[name=\'country_id\']').trigger('change');
+//--></script>
+
+<script type="text/javascript"><!--
+$('input[name=\'payment\']').on('change', function() {
+  $('.payment').hide();
+  $('#payment-' + this.value).show();
+});
+
+$('input[name=\'payment\']:checked').trigger('change');
+//--></script>
+
+<script type="text/javascript"><!--
+$('#transaction .pagination a').live('click', function() {
+  $('#transaction').load(this.href);
+  return false;
+});
+
+$('#transaction').load('index.php?route=marketing/affiliate/transaction&token=<?php echo $token; ?>&affiliate_id=<?php echo $affiliate_id; ?>');
+
+function addTransaction() {
+  $.ajax({
+    url: 'index.php?route=marketing/affiliate/transaction&token=<?php echo $token; ?>&affiliate_id=<?php echo $affiliate_id; ?>',
+    type: 'post',
+    dataType: 'html',
+    data: 'description=' + encodeURIComponent($('#tab-transaction input[name=\'description\']').val()) + '&amount=' + encodeURIComponent($('#tab-transaction input[name=\'amount\']').val()),
+    beforeSend: function() {
+      $('.success, .warning').remove();
+      $('#button-transaction').attr('disabled', true);
+      $('#transaction').before('<div class="attention"><img src="view/image/loading.gif" alt="" /> <?php echo $text_wait; ?></div>');
+    },
+    complete: function() {
+      $('#button-transaction').attr('disabled', false);
+      $('.attention').remove();
+    },
+    success: function(html) {
+      $('#transaction').html(html);
+
+        $('#tab-transaction input[name=\'amount\']').val('');
+        $('#tab-transaction input[name=\'description\']').val('');
+      }
+  });
+}
+//--></script>
+
+<script type="text/javascript"><!--
+$('.htabs a').tabs();
+//--></script>
+<?php echo $footer; ?>

--- a/upload/admin/view/template/marketing/affiliate_list.tpl
+++ b/upload/admin/view/template/marketing/affiliate_list.tpl
@@ -1,0 +1,233 @@
+<?php echo $header; ?>
+<div id="content">
+  <div class="breadcrumb">
+  <?php foreach ($breadcrumbs as $breadcrumb) { ?>
+    <?php echo $breadcrumb['separator']; ?><a href="<?php echo $breadcrumb['href']; ?>"><?php echo $breadcrumb['text']; ?></a>
+  <?php } ?>
+  </div>
+  <?php if ($error_warning) { ?>
+    <div class="warning"><?php echo $error_warning; ?></div>
+  <?php } ?>
+  <?php if ($success) { ?>
+    <div class="success"><?php echo $success; ?></div>
+  <?php } ?>
+  <div class="box">
+    <div class="heading">
+      <h1><img src="view/image/customer.png" alt="" /> <?php echo $heading_title; ?></h1>
+      <div class="buttons">
+        <a onclick="$('form').attr('action','<?php echo $approve; ?>'); $('form').submit();" class="button-save"><?php echo $button_approve; ?></a>
+        <a href="<?php echo $insert; ?>" class="button"><?php echo $button_insert; ?></a>
+        <a onclick="$('form').attr('action','<?php echo $delete; ?>'); $('form').submit();" class="button-delete"><?php echo $button_delete; ?></a>
+      </div>
+    </div>
+    <div class="content">
+    <?php if ($navigation_hi) { ?>
+      <div class="pagination" style="margin-bottom:10px;"><?php echo $pagination; ?></div>
+    <?php } ?>
+    <form action="" method="post" enctype="multipart/form-data" id="form">
+      <table class="list">
+      <thead>
+        <tr>
+          <td width="1" style="text-align:center;"><input type="checkbox" onclick="$('input[name*=\'selected\']').attr('checked', this.checked);" id="check-all" class="checkbox" />
+          <label for="check-all"><span></span></label></td>
+          <td class="left"><?php if ($sort == 'name') { ?>
+            <a href="<?php echo $sort_name; ?>" class="<?php echo strtolower($order); ?>"><?php echo $column_name; ?></a>
+          <?php } else { ?>
+            <a href="<?php echo $sort_name; ?>"><?php echo $column_name; ?>&nbsp;&nbsp;<img src="view/image/sort.png" alt="" /></a>
+          <?php } ?></td>
+          <td class="left"><?php if ($sort == 'c.email') { ?>
+            <a href="<?php echo $sort_email; ?>" class="<?php echo strtolower($order); ?>"><?php echo $column_email; ?></a>
+          <?php } else { ?>
+            <a href="<?php echo $sort_email; ?>"><?php echo $column_email; ?>&nbsp;&nbsp;<img src="view/image/sort.png" alt="" /></a>
+          <?php } ?></td>
+          <td class="left"><?php echo $column_balance; ?></td>
+          <td class="left"><?php if ($sort == 'c.approved') { ?>
+            <a href="<?php echo $sort_approved; ?>" class="<?php echo strtolower($order); ?>"><?php echo $column_approved; ?></a>
+          <?php } else { ?>
+            <a href="<?php echo $sort_approved; ?>"><?php echo $column_approved; ?>&nbsp;&nbsp;<img src="view/image/sort.png" alt="" /></a>
+          <?php } ?></td>
+          <td class="left"><?php if ($sort == 'c.date_added') { ?>
+            <a href="<?php echo $sort_date_added; ?>" class="<?php echo strtolower($order); ?>"><?php echo $column_date_added; ?></a>
+          <?php } else { ?>
+            <a href="<?php echo $sort_date_added; ?>"><?php echo $column_date_added; ?>&nbsp;&nbsp;<img src="view/image/sort.png" alt="" /></a>
+          <?php } ?></td>
+          <td class="left"><?php if ($sort == 'c.status') { ?>
+            <a href="<?php echo $sort_status; ?>" class="<?php echo strtolower($order); ?>"><?php echo $column_status; ?></a>
+          <?php } else { ?>
+            <a href="<?php echo $sort_status; ?>"><?php echo $column_status; ?>&nbsp;&nbsp;<img src="view/image/sort.png" alt="" /></a>
+          <?php } ?></td>
+          <td class="right"><?php echo $column_action; ?></td>
+        </tr>
+      </thead>
+      <tbody>
+        <tr class="filter">
+          <td></td>
+          <td><input type="text" name="filter_name" value="<?php echo $filter_name; ?>" /></td>
+          <td><input type="text" name="filter_email" value="<?php echo $filter_email; ?>" /></td>
+          <td>&nbsp;</td>
+          <td class="center"><select name="filter_approved">
+            <option value="*"></option>
+            <?php if ($filter_approved) { ?>
+              <option value="1" selected="selected"><?php echo $text_yes; ?></option>
+            <?php } else { ?>
+              <option value="1"><?php echo $text_yes; ?></option>
+            <?php } ?>
+            <?php if (!is_null($filter_approved) && !$filter_approved) { ?>
+              <option value="0" selected="selected"><?php echo $text_no; ?></option>
+            <?php } else { ?>
+              <option value="0"><?php echo $text_no; ?></option>
+            <?php } ?>
+          </select></td>
+          <td class="center"><input type="text" name="filter_date_added" value="<?php echo $filter_date_added; ?>" size="12" id="date" /></td>
+          <td class="center"><select name="filter_status">
+            <option value="*"></option>
+            <?php if ($filter_status) { ?>
+              <option value="1" selected="selected"><?php echo $text_enabled; ?></option>
+            <?php } else { ?>
+              <option value="1"><?php echo $text_enabled; ?></option>
+            <?php } ?>
+            <?php if (!is_null($filter_status) && !$filter_status) { ?>
+              <option value="0" selected="selected"><?php echo $text_disabled; ?></option>
+            <?php } else { ?>
+              <option value="0"><?php echo $text_disabled; ?></option>
+            <?php } ?>
+          </select></td>
+          <td class="right"><a onclick="filter();" class="button-filter"><?php echo $button_filter; ?></a></td>
+        </tr>
+        <?php if ($affiliates) { ?>
+          <?php foreach ($affiliates as $affiliate) { ?>
+          <tr>
+            <td style="text-align:center;"><?php if ($affiliate['selected']) { ?>
+              <input type="checkbox" name="selected[]" value="<?php echo $affiliate['affiliate_id']; ?>" id="<?php echo $affiliate['affiliate_id']; ?>" class="checkbox" checked />
+              <label for="<?php echo $affiliate['affiliate_id']; ?>"><span></span></label>
+            <?php } else { ?>
+              <input type="checkbox" name="selected[]" value="<?php echo $affiliate['affiliate_id']; ?>" id="<?php echo $affiliate['affiliate_id']; ?>" class="checkbox" />
+              <label for="<?php echo $affiliate['affiliate_id']; ?>"><span></span></label>
+            <?php } ?></td>
+            <td class="left"><?php echo $affiliate['name']; ?></td>
+            <td class="left"><?php echo $affiliate['email']; ?></td>
+            <td class="center"><?php echo $affiliate['balance']; ?></td>
+            <td class="center"><?php echo $affiliate['approved']; ?></td>
+            <td class="center"><?php echo $affiliate['date_added']; ?></td>
+            <?php if ($affiliate['status'] == 1) { ?>
+              <td class="center"><span class="enabled"><?php echo $text_enabled; ?></span></td>
+            <?php } else { ?>
+              <td class="center"><span class="disabled"><?php echo $text_disabled; ?></span></td>
+            <?php } ?>
+            <td class="right"><?php foreach ($affiliate['action'] as $action) { ?>
+              <a href="<?php echo $action['href']; ?>" class="button-form"><?php echo $action['text']; ?></a>
+            <?php } ?></td>
+          </tr>
+          <?php } ?>
+        <?php } else { ?>
+          <tr>
+            <td class="center" colspan="8"><?php echo $text_no_results; ?></td>
+          </tr>
+        <?php } ?>
+      </tbody>
+      </table>
+    </form>
+    <?php if ($navigation_lo) { ?>
+      <div class="pagination"><?php echo $pagination; ?></div>
+    <?php } ?>
+    </div>
+  </div>
+</div>
+
+<script type="text/javascript"><!--
+function filter() {
+  url = 'index.php?route=marketing/affiliate&token=<?php echo $token; ?>';
+
+  var filter_name = $('input[name=\'filter_name\']').val();
+
+  if (filter_name) {
+    url += '&filter_name=' + encodeURIComponent(filter_name);
+  }
+
+  var filter_email = $('input[name=\'filter_email\']').val();
+
+  if (filter_email) {
+    url += '&filter_email=' + encodeURIComponent(filter_email);
+  }
+
+  var filter_approved = $('select[name=\'filter_approved\']').val();
+
+  if (filter_approved != '*') {
+    url += '&filter_approved=' + encodeURIComponent(filter_approved);
+  }
+
+  var filter_date_added = $('input[name=\'filter_date_added\']').val();
+
+  if (filter_date_added) {
+    url += '&filter_date_added=' + encodeURIComponent(filter_date_added);
+  }
+
+  var filter_status = $('select[name=\'filter_status\']').val();
+
+  if (filter_status != '*') {
+    url += '&filter_status=' + encodeURIComponent(filter_status);
+  }
+
+  location = url;
+}
+//--></script>
+
+<script type="text/javascript"><!--
+$('input[name=\'filter_name\']').autocomplete({
+  delay: 10,
+  source: function(request, response) {
+    $.ajax({
+      url: 'index.php?route=marketing/affiliate/autocomplete&token=<?php echo $token; ?>&filter_name=' + encodeURIComponent(request),
+      dataType: 'json',
+      success: function(json) {
+        response($.map(json, function(item) {
+          return {
+            label: item.name,
+            value: item.affiliate_id
+          }
+        }));
+      }
+    });
+  },
+  select: function(event, ui) {
+    $('input[name=\'filter_name\']').val(ui.item.label);
+    return false;
+  },
+  focus: function(event, ui) {
+    return false;
+  }
+});
+
+$('input[name=\'filter_email\']').autocomplete({
+  delay: 10,
+  source: function(request, response) {
+    $.ajax({
+      url: 'index.php?route=marketing/affiliate/autocomplete&token=<?php echo $token; ?>&filter_email=' +  encodeURIComponent(request),
+      dataType: 'json',
+      success: function(json) {
+        response($.map(json, function(item) {
+          return {
+            label: item.email,
+            value: item.affiliate_id
+          }
+        }));
+      }
+    });
+  },
+  select: function(event, ui) {
+    $('input[name=\'filter_email\']').val(ui.item.label);
+    return false;
+  },
+  focus: function(event, ui) {
+    return false;
+  }
+});
+//--></script>
+
+<script type="text/javascript"><!--
+$(document).ready(function() {
+  $('#date').datepicker({dateFormat: 'yy-mm-dd'});
+});
+//--></script>
+
+<?php echo $footer; ?>

--- a/upload/admin/view/template/marketing/affiliate_transaction.tpl
+++ b/upload/admin/view/template/marketing/affiliate_transaction.tpl
@@ -1,0 +1,41 @@
+<?php if ($error_warning) { ?>
+  <div class="warning"><?php echo $error_warning; ?></div>
+<?php } ?>
+<?php if ($success) { ?>
+  <div class="success"><?php echo $success; ?></div>
+<?php } ?>
+<?php if ($navigation_hi) { ?>
+  <div class="pagination" style="margin-bottom:10px;"><?php echo $pagination; ?></div>
+<?php } ?>
+<table class="list">
+  <thead>
+    <tr>
+      <td class="left"><?php echo $column_date_added; ?></td>
+      <td class="left"><?php echo $column_description; ?></td>
+      <td class="right"><?php echo $column_amount; ?></td>
+    </tr>
+  </thead>
+  <tbody>
+    <?php if ($transactions) { ?>
+    <?php foreach ($transactions as $transaction) { ?>
+    <tr>
+      <td class="left"><?php echo $transaction['date_added']; ?></td>
+      <td class="left"><?php echo $transaction['description']; ?></td>
+      <td class="right"><?php echo $transaction['amount']; ?></td>
+    </tr>
+    <?php } ?>
+    <tr>
+      <td>&nbsp;</td>
+      <td class="right"><b><?php echo $text_balance; ?></b></td>
+      <td class="right"><?php echo $balance; ?></td>
+    </tr>
+    <?php } else { ?>
+    <tr>
+      <td class="center" colspan="3"><?php echo $text_no_results; ?></td>
+    </tr>
+    <?php } ?>
+  </tbody>
+</table>
+<?php if ($navigation_lo) { ?>
+  <div class="pagination"><?php echo $pagination; ?></div>
+<?php } ?>

--- a/upload/admin/view/template/marketing/contact.tpl
+++ b/upload/admin/view/template/marketing/contact.tpl
@@ -1,0 +1,281 @@
+<?php echo $header; ?>
+<div id="content">
+  <div class="breadcrumb">
+  <?php foreach ($breadcrumbs as $breadcrumb) { ?>
+    <?php echo $breadcrumb['separator']; ?><a href="<?php echo $breadcrumb['href']; ?>"><?php echo $breadcrumb['text']; ?></a>
+  <?php } ?>
+  </div>
+  <div class="box">
+    <div class="heading">
+      <h1><img src="view/image/mail.png" alt="" /> <?php echo $heading_title; ?></h1>
+      <div class="buttons">
+        <a id="button-send" onclick="send('index.php?route=marketing/contact/send&token=<?php echo $token; ?>');" class="button"><?php echo $button_send; ?></a>
+        <a href="<?php echo $cancel; ?>" class="button-cancel"><?php echo $button_cancel; ?></a>
+      </div>
+    </div>
+    <div class="content">
+      <table id="mail" class="form">
+        <tr>
+          <td><label for="input-store"><?php echo $entry_store; ?></label></td>
+          <td><select name="store_id" id="input-store">
+            <option value="0"><?php echo $text_default; ?></option>
+            <?php foreach ($stores as $store) { ?>
+              <option value="<?php echo $store['store_id']; ?>"><?php echo $store['name']; ?></option>
+            <?php } ?>
+          </select></td>
+        </tr>
+        <tr>
+          <td><label for="input-to"><?php echo $entry_to; ?></label></td>
+          <td><select name="to" id="input-to">
+            <option value="newsletter"><?php echo $text_newsletter; ?></option>
+            <option value="customer_all"><?php echo $text_customer_all; ?></option>
+            <option value="customer_group"><?php echo $text_customer_group; ?></option>
+            <option value="customer"><?php echo $text_customer; ?></option>
+            <option value="affiliate_all"><?php echo $text_affiliate_all; ?></option>
+            <option value="affiliate"><?php echo $text_affiliate; ?></option>
+            <option value="product"><?php echo $text_product; ?></option>
+          </select></td>
+        </tr>
+        <tbody id="to-customer-group" class="to">
+        <tr>
+          <td><label for="input-customer-group"><?php echo $entry_customer_group; ?></label></td>
+          <td><select name="customer_group_id" id="input-customer-group">
+            <?php foreach ($customer_groups as $customer_group) { ?>
+              <option value="<?php echo $customer_group['customer_group_id']; ?>"><?php echo $customer_group['name']; ?></option>
+            <?php } ?>
+          </select></td>
+        </tr>
+        </tbody>
+        <tbody id="to-customer" class="to">
+        <tr>
+          <td><label for="input-customer"><?php echo $entry_customer; ?><br /><span class="help"><?php echo $help_customer; ?></span></label></td>
+          <td><input type="text" name="customers" id="input-customer" value="" /></td>
+        </tr>
+        <tr>
+          <td>&nbsp;</td>
+          <td><div id="customer" class="scrollbox"></div></td>
+        </tr>
+        </tbody>
+        <tbody id="to-affiliate" class="to">
+        <tr>
+          <td><label for="input-affiliate"><?php echo $entry_affiliate; ?><br /><span class="help"><?php echo $help_affiliate; ?></span></label></td>
+          <td><input type="text" name="affiliates" id="input-affiliate" value="" /></td>
+        </tr>
+        <tr>
+          <td>&nbsp;</td>
+          <td><div id="affiliate" class="scrollbox"></div></td>
+        </tr>
+        </tbody>
+        <tbody id="to-product" class="to">
+        <tr>
+          <td><label for="input-product"><?php echo $entry_product; ?><br /><span class="help"><?php echo $help_product; ?></span></label></td>
+          <td><input type="text" name="products" id="input-product" value="" /></td>
+        </tr>
+        <tr>
+          <td>&nbsp;</td>
+          <td><div id="product" class="scrollbox"></div></td>
+        </tr>
+        </tbody>
+        <tr>
+          <td><span class="required">*</span>&nbsp;<label for="input-subject"><?php echo $entry_subject; ?></label></td>
+          <td><input type="text" name="subject" id="input-subject" value="" size="60" /></td>
+        </tr>
+        <tr>
+          <td><span class="required">*</span>&nbsp;<label for="input-message"><?php echo $entry_message; ?></label></td>
+          <td><textarea name="message" id="input-message"></textarea></td>
+        </tr>
+      </table>
+    </div>
+  </div>
+</div>
+
+<script type="text/javascript" src="view/javascript/ckeditor/ckeditor.js"></script>
+
+<script type="text/javascript"><!--
+CKEDITOR.replace('message', {
+  filebrowserBrowseUrl: 'index.php?route=common/filemanager&token=<?php echo $token; ?>',
+  filebrowserImageBrowseUrl: 'index.php?route=common/filemanager&token=<?php echo $token; ?>',
+  filebrowserFlashBrowseUrl: 'index.php?route=common/filemanager&token=<?php echo $token; ?>'
+});
+//--></script>
+
+<script type="text/javascript"><!--
+$('select[name=\'to\']').on('change', function() {
+  $('#mail .to').hide();
+  $('#mail #to-' + this.value.replace('_', '-')).show();
+});
+
+$('select[name=\'to\']').trigger('change');
+//--></script>
+
+<script type="text/javascript"><!--
+// Customers
+$('input[name=\'customers\']').autocomplete({
+  delay: 10,
+  source: function(request, response) {
+    $.ajax({
+      url: 'index.php?route=sale/customer/autocomplete&token=<?php echo $token; ?>&filter_name=' + encodeURIComponent(request.term),
+      dataType: 'json',
+      success: function(json) {
+        response($.map(json, function(item) {
+          return {
+            customer_group: item.customer_group,
+            label: item.name,
+            value: item.customer_id
+          }
+        }));
+      }
+    });
+  },
+  select: function(event, ui) {
+    $('#customer' + ui.item.value).remove();
+
+    $('#customer').append('<div id="customer' + ui.item.value + '">' + ui.item.label + '<img src="view/image/delete.png" alt="" /><input type="hidden" name="customer[]" value="' + ui.item.value + '" /></div>');
+
+    $('#customer div:odd').attr('class', 'odd');
+    $('#customer div:even').attr('class', 'even');
+
+    return false;
+  },
+  focus: function(event, ui) {
+    return false;
+  }
+});
+
+$('#customer div img').live('click', function() {
+  $(this).parent().remove();
+
+  $('#customer div:odd').attr('class', 'odd');
+  $('#customer div:even').attr('class', 'even');
+});
+
+// Affiliates
+$('input[name=\'affiliates\']').autocomplete({
+  delay: 10,
+  source: function(request, response) {
+    $.ajax({
+      url: 'index.php?route=marketing/affiliate/autocomplete&token=<?php echo $token; ?>&filter_name=' + encodeURIComponent(request.term),
+      dataType: 'json',
+      success: function(json) {
+        response($.map(json, function(item) {
+          return {
+            label: item.name,
+            value: item.affiliate_id
+          }
+        }));
+      }
+    });
+  },
+  select: function(event, ui) {
+    $('#affiliate' + ui.item.value).remove();
+
+    $('#affiliate').append('<div id="affiliate' + ui.item.value + '">' + ui.item.label + '<img src="view/image/delete.png" alt="" /><input type="hidden" name="affiliate[]" value="' + ui.item.value + '" /></div>');
+
+    $('#affiliate div:odd').attr('class', 'odd');
+    $('#affiliate div:even').attr('class', 'even');
+
+    return false;
+  },
+  focus: function(event, ui) {
+    return false;
+  }
+});
+
+$('#affiliate div img').live('click', function() {
+  $(this).parent().remove();
+
+  $('#affiliate div:odd').attr('class', 'odd');
+  $('#affiliate div:even').attr('class', 'even');
+});
+
+// Products
+$('input[name=\'products\']').autocomplete({
+  delay: 10,
+  source: function(request, response) {
+    $.ajax({
+      url: 'index.php?route=catalog/product/autocomplete&token=<?php echo $token; ?>&filter_name=' + encodeURIComponent(request.term),
+      dataType: 'json',
+      success: function(json) {
+        response($.map(json, function(item) {
+          return {
+            label: item.name,
+            value: item.product_id
+          }
+        }));
+      }
+    });
+  },
+  select: function(event, ui) {
+    $('#product' + ui.item.value).remove();
+
+    $('#product').append('<div id="product' + ui.item.value + '">' + ui.item.label + '<img src="view/image/delete.png" alt="" /><input type="hidden" name="product[]" value="' + ui.item.value + '" /></div>');
+
+    $('#product div:odd').attr('class', 'odd');
+    $('#product div:even').attr('class', 'even');
+
+    return false;
+  },
+  focus: function(event, ui) {
+    return false;
+  }
+});
+
+$('#product div img').live('click', function() {
+  $(this).parent().remove();
+
+  $('#product div:odd').attr('class', 'odd');
+  $('#product div:even').attr('class', 'even');
+});
+
+function send(url) {
+  if (typeof CKEDITOR !== "undefined" && CKEDITOR.instances['input-message']) CKEDITOR.instances['input-message'].updateElement();
+
+  $.ajax({
+    url: url,
+    type: 'post',
+    data: $('select, input, textarea'),
+    dataType: 'json',
+    beforeSend: function() {
+      $('#button-send').prop('disabled', true);
+      $('#button-send').before('<span class="wait"><img src="view/image/loading.gif" alt="" />&nbsp;</span>');
+    },
+    complete: function() {
+      $('#button-send').prop('disabled', false);
+      $('.wait').remove();
+    },
+    success: function(json) {
+      $('.success, .warning, .error').remove();
+
+      if (json['error']) {
+        if (json['error']['warning']) {
+          $('.box').before('<div class="warning" style="display:none;">' + json['error']['warning'] + '</div>');
+          $('.warning').fadeIn('slow');
+        }
+
+        if (json['error']['subject']) {
+          $('input[name=\'subject\']').after('<span class="error">' + json['error']['subject'] + '</span>');
+        }
+
+        if (json['error']['message']) {
+          $('textarea[name=\'message\']').parent().append('<span class="error">' + json['error']['message'] + '</span>');
+        }
+      }
+
+      if (json['next']) {
+        if (json['success']) {
+          $('.box').before('<div class="success">' + json['success'] + '</div>');
+
+          send(json['next']);
+        }
+      } else {
+        if (json['success']) {
+          $('.box').before('<div class="success" style="display:none;">' + json['success'] + '</div>');
+          $('.success').fadeIn('slow');
+        }
+      }
+    }
+  });
+}
+//--></script>
+
+<?php echo $footer; ?>

--- a/upload/admin/view/template/marketing/coupon_form.tpl
+++ b/upload/admin/view/template/marketing/coupon_form.tpl
@@ -1,0 +1,280 @@
+<?php echo $header; ?>
+<div id="content">
+  <div class="breadcrumb">
+  <?php foreach ($breadcrumbs as $breadcrumb) { ?>
+    <?php echo $breadcrumb['separator']; ?><a href="<?php echo $breadcrumb['href']; ?>"><?php echo $breadcrumb['text']; ?></a>
+  <?php } ?>
+  </div>
+  <?php if ($error_warning) { ?>
+    <div class="warning"><?php echo $error_warning; ?></div>
+  <?php } ?>
+  <?php if ($success) { ?>
+    <div class="success"><?php echo $success; ?></div>
+  <?php } ?>
+  <div class="box">
+    <div class="heading">
+      <h1><img src="view/image/offer.png" alt="" /> <?php echo $heading_title; ?></h1>
+      <div class="buttons">
+        <a onclick="$('#form').submit();" class="button-save"><?php echo $button_save; ?></a>
+        <a onclick="apply();" class="button-save"><?php echo $button_apply; ?></a>
+        <a href="<?php echo $cancel; ?>" class="button-cancel"><?php echo $button_cancel; ?></a>
+      </div>
+    </div>
+    <div class="content">
+    <div id="tabs" class="htabs">
+      <a href="#tab-general"><?php echo $tab_general; ?></a>
+      <?php if ($coupon_id) { ?>
+        <a href="#tab-history"><?php echo $tab_history; ?></a>
+      <?php } ?>
+    </div>
+    <form action="<?php echo $action; ?>" method="post" enctype="multipart/form-data" id="form">
+      <div id="tab-general">
+        <table class="form">
+          <tr>
+            <td><span class="required">*</span>&nbsp;<label for="input-name"><?php echo $entry_name; ?></label></td>
+            <td><?php if ($error_name) { ?>
+              <input type="text" name="name" id="input-name" value="<?php echo $name; ?>" class="input-error" />
+              <span class="error"><?php echo $error_name; ?></span>
+            <?php } else { ?>
+              <input type="text" name="name" id="input-name" value="<?php echo $name; ?>" />
+            <?php } ?></td>
+          </tr>
+          <tr>
+            <td><span class="required">*</span> <label for="input-code"><?php echo $entry_code; ?><br /><span class="help"><?php echo $help_code; ?></span></label></td>
+            <td><?php if ($error_code) { ?>
+              <input type="text" name="code" id="input-code" value="<?php echo $code; ?>" class="input-error" />
+              <span class="error"><?php echo $error_code; ?></span>
+            <?php } else { ?>
+              <input type="text" name="code" id="input-code" value="<?php echo $code; ?>" />
+            <?php } ?></td>
+          </tr>
+          <tr>
+            <td><label for="input-type"><?php echo $entry_type; ?><br /><span class="help"><?php echo $help_type; ?></span></label></td>
+            <td><select name="type" id="input-type">
+              <?php if ($type == 'P') { ?>
+                <option value="P" selected="selected"><?php echo $text_percent; ?></option>
+              <?php } else { ?>
+                <option value="P"><?php echo $text_percent; ?></option>
+              <?php } ?>
+              <?php if ($type == 'F') { ?>
+                <option value="F" selected="selected"><?php echo $text_amount; ?></option>
+              <?php } else { ?>
+                <option value="F"><?php echo $text_amount; ?></option>
+              <?php } ?>
+            </select></td>
+          </tr>
+          <tr>
+            <td><label for="input-discount"><?php echo $entry_discount; ?></label></td>
+            <td><input type="text" name="discount" id="input-discount" value="<?php echo $discount; ?>" /></td>
+          </tr>
+          <tr>
+            <td><label for="input-total"><?php echo $entry_total; ?><br /><span class="help"><?php echo $help_total; ?></span></label></td>
+            <td><input type="text" name="total" id="input-total" value="<?php echo $total; ?>" /></td>
+          </tr>
+          <tr>
+            <td><label for="input-logged"><?php echo $entry_logged; ?><br /><span class="help"><?php echo $help_logged; ?></span></label></td>
+            <td><?php if ($logged) { ?>
+              <input type="radio" name="logged" value="1" id="input-logged-on" class="radio" checked />
+              <label for="input-logged-on"><span><span></span></span><?php echo $text_yes; ?></label>
+              <input type="radio" name="logged" value="0" id="logged-off" class="radio" />
+              <label for="input-logged-off"><span><span></span></span><?php echo $text_no; ?></label>
+            <?php } else { ?>
+              <input type="radio" name="logged" value="1" id="input-logged-on" class="radio" />
+              <label for="input-logged-on"><span><span></span></span><?php echo $text_yes; ?></label>
+              <input type="radio" name="logged" value="0" id="input-logged-off" class="radio" checked />
+              <label for="input-logged-off"><span><span></span></span><?php echo $text_no; ?></label>
+            <?php } ?></td>
+          </tr>
+          <tr>
+            <td><?php echo $entry_shipping; ?></td>
+            <td><?php if ($shipping) { ?>
+              <input type="radio" name="shipping" value="1" id="input-shipping-on" class="radio" checked />
+              <label for="input-shipping-on"><span></span><?php echo $text_yes; ?></label>
+              <input type="radio" name="shipping" value="0" id="input-shipping-off" class="radio" />
+              <label for="input-shipping-off"><span><span></span></span><?php echo $text_no; ?></label>
+            <?php } else { ?>
+              <input type="radio" name="shipping" value="1" id="input-shipping-on" class="radio" />
+              <label for="input-shipping-on"><span><span></span></span><?php echo $text_yes; ?></label>
+              <input type="radio" name="shipping" value="0" id="input-shipping-off" class="radio" checked />
+              <label for="input-shipping-off"><span><span></span></span><?php echo $text_no; ?></label>
+            <?php } ?></td>
+          </tr>
+          <tr>
+            <td><label for="input-product"><?php echo $entry_product; ?><br /><span class="help"><?php echo $help_product; ?></span></label></td>
+            <td><input type="text" name="product" id="input-product" value="" /></td>
+          </tr>
+          <tr>
+            <td>&nbsp;</td>
+            <td><div id="coupon-product" class="scrollbox">
+              <?php $class = 'odd'; ?>
+              <?php foreach ($coupon_products as $coupon_product) { ?>
+                <?php $class = ($class == 'even' ? 'odd' : 'even'); ?>
+                <div id="coupon-product<?php echo $coupon_product['product_id']; ?>" class="<?php echo $class; ?>"> <?php echo $coupon_product['name']; ?><img src="view/image/delete.png" alt="" />
+                  <input type="hidden" name="coupon_product[]" value="<?php echo $coupon_product['product_id']; ?>" />
+                </div>
+              <?php } ?>
+            </div></td>
+          </tr>
+          <tr>
+            <td><label for="input-category"><?php echo $entry_category; ?><br /><span class="help"><?php echo $help_category; ?></span></label></td>
+            <td><input type="text" name="category" id="input-category" value="" /></td>
+          </tr>
+          <tr>
+            <td>&nbsp;</td>
+            <td><div id="coupon-category" class="scrollbox">
+              <?php $class = 'odd'; ?>
+              <?php foreach ($coupon_categories as $coupon_category) { ?>
+                <?php $class = ($class == 'even' ? 'odd' : 'even'); ?>
+                <div id="coupon-category<?php echo $coupon_category['category_id']; ?>" class="<?php echo $class; ?>"> <?php echo $coupon_category['name']; ?><img src="view/image/delete.png" alt="" />
+                  <input type="hidden" name="coupon_category[]" value="<?php echo $coupon_category['category_id']; ?>" />
+                </div>
+              <?php } ?>
+            </div></td>
+          </tr>
+          <tr>
+            <td><label for="input-date-start"><?php echo $entry_date_start; ?></label></td>
+            <td><input type="text" name="date_start" id="input-date-start" value="<?php echo $date_start; ?>" size="12" />
+            <span class="form-icon"><img src="view/image/calendar.png" alt="" /></span></td>
+          </tr>
+          <tr>
+            <td><label for="input-date-end"><?php echo $entry_date_end; ?></label></td>
+            <td><input type="text" name="date_end" id="input-date-end" value="<?php echo $date_end; ?>" size="12" />
+            <span class="form-icon"><img src="view/image/calendar.png" alt="" /></span></td>
+          </tr>
+          <tr>
+            <td><label for="input-uses-total"><?php echo $entry_uses_total; ?><br /><span class="help"><?php echo $help_uses_total; ?></span></label></td>
+            <td><input type="text" name="uses_total" id="input-uses-total" value="<?php echo $uses_total; ?>" /></td>
+          </tr>
+          <tr>
+            <td><label for="input-uses-customer"><?php echo $entry_uses_customer; ?><br /><span class="help"><?php echo $help_uses_customer; ?></span></label></td>
+            <td><input type="text" name="uses_customer" id="input-uses-customer" value="<?php echo $uses_customer; ?>" /></td>
+          </tr>
+          <tr>
+            <td><label for="input-status"><?php echo $entry_status; ?></label></td>
+            <td><select name="status" id="input-status">
+              <?php if ($status) { ?>
+                <option value="1" selected="selected"><?php echo $text_enabled; ?></option>
+                <option value="0"><?php echo $text_disabled; ?></option>
+              <?php } else { ?>
+                <option value="1"><?php echo $text_enabled; ?></option>
+                <option value="0" selected="selected"><?php echo $text_disabled; ?></option>
+              <?php } ?>
+            </select></td>
+          </tr>
+        </table>
+      </div>
+      <?php if ($coupon_id) { ?>
+        <div id="tab-history">
+          <div id="history"></div>
+        </div>
+      <?php } ?>
+    </form>
+    </div>
+  </div>
+</div>
+<script type="text/javascript"><!--
+$('input[name=\'product\']').autocomplete({
+  delay: 10,
+  source: function(request, response) {
+    $.ajax({
+      url: 'index.php?route=catalog/product/autocomplete&token=<?php echo $token; ?>&filter_name=' + encodeURIComponent(request.term),
+      dataType: 'json',
+      success: function(json) {
+        response($.map(json, function(item) {
+          return {
+            label: item.name,
+            value: item.product_id
+          }
+        }));
+      }
+    });
+  },
+  select: function(event, ui) {
+    $('#coupon-product' + ui.item.value).remove();
+
+    $('#coupon-product').append('<div id="coupon-product' + ui.item.value + '">' + ui.item.label + '<img src="view/image/delete.png" alt="" /><input type="hidden" name="coupon_product[]" value="' + ui.item.value + '" /></div>');
+
+    $('#coupon-product div:odd').attr('class', 'odd');
+    $('#coupon-product div:even').attr('class', 'even');
+
+    $('input[name=\'product\']').val('');
+
+    return false;
+  },
+  focus: function(event, ui) {
+    return false;
+  }
+});
+
+$('#coupon-product div img').live('click', function() {
+  $(this).parent().remove();
+
+  $('#coupon-product div:odd').attr('class', 'odd');
+  $('#coupon-product div:even').attr('class', 'even');
+});
+
+// Category
+$('input[name=\'category\']').autocomplete({
+  delay: 10,
+  source: function(request, response) {
+    $.ajax({
+      url: 'index.php?route=catalog/category/autocomplete&token=<?php echo $token; ?>&filter_name=' + encodeURIComponent(request.term),
+      dataType: 'json',
+      success: function(json) {
+        response($.map(json, function(item) {
+          return {
+            label: item.name,
+            value: item.category_id
+          }
+        }));
+      }
+    });
+  },
+  select: function(event, ui) {
+    $('#coupon-category' + ui.item.value).remove();
+
+    $('#coupon-category').append('<div id="coupon-category' + ui.item.value + '">' + ui.item.label + '<img src="view/image/delete.png" alt="" /><input type="hidden" name="coupon_category[]" value="' + ui.item.value + '" /></div>');
+
+    $('#coupon-category div:odd').attr('class', 'odd');
+    $('#coupon-category div:even').attr('class', 'even');
+
+    $('input[name=\'category\']').val('');
+
+    return false;
+  },
+  focus: function(event, ui) {
+    return false;
+  }
+});
+
+$('#coupon-category div img').live('click', function() {
+  $(this).parent().remove();
+
+  $('#coupon-category div:odd').attr('class', 'odd');
+  $('#coupon-category div:even').attr('class', 'even');
+});
+//--></script>
+
+<script type="text/javascript"><!--
+$(document).ready(function() {
+  $('#date-start').datepicker({dateFormat: 'yy-mm-dd'});
+  $('#date-end').datepicker({dateFormat: 'yy-mm-dd'});
+});
+//--></script>
+
+<?php if ($coupon_id) { ?>
+<script type="text/javascript"><!--
+$('#history .pagination a').live('click', function() {
+  $('#history').load(this.href);
+  return false;
+});
+
+$('#history').load('index.php?route=marketing/coupon/history&token=<?php echo $token; ?>&coupon_id=<?php echo $coupon_id; ?>');
+//--></script>
+<?php } ?>
+
+<script type="text/javascript"><!--
+$('#tabs a').tabs();
+//--></script>
+
+<?php echo $footer; ?>

--- a/upload/admin/view/template/marketing/coupon_history.tpl
+++ b/upload/admin/view/template/marketing/coupon_history.tpl
@@ -1,0 +1,32 @@
+<?php if ($navigation_hi) { ?>
+  <div class="pagination" style="margin-bottom:10px;"><?php echo $pagination; ?></div>
+<?php } ?>
+<table class="list">
+  <thead>
+    <tr>
+      <td class="left"><?php echo $column_order_id; ?></td>
+      <td class="left"><?php echo $column_customer; ?></td>
+      <td class="left"><?php echo $column_date_added; ?></td>
+      <td class="right"><?php echo $column_amount; ?></td>
+    </tr>
+  </thead>
+  <tbody>
+  <?php if ($histories) { ?>
+    <?php foreach ($histories as $history) { ?>
+    <tr>
+      <td class="center"><?php echo $history['order_id']; ?></td>
+      <td class="left"><?php echo $history['customer']; ?></td>
+      <td class="center"><?php echo $history['date_added']; ?></td>
+      <td class="right"><?php echo $history['amount']; ?></td>
+    </tr>
+    <?php } ?>
+  <?php } else { ?>
+    <tr>
+      <td class="center" colspan="4"><?php echo $text_no_results; ?></td>
+    </tr>
+  <?php } ?>
+  </tbody>
+</table>
+<?php if ($navigation_lo) { ?>
+  <div class="pagination"><?php echo $pagination; ?></div>
+<?php } ?>

--- a/upload/admin/view/template/marketing/coupon_list.tpl
+++ b/upload/admin/view/template/marketing/coupon_list.tpl
@@ -1,0 +1,105 @@
+<?php echo $header; ?>
+<div id="content">
+  <div class="breadcrumb">
+  <?php foreach ($breadcrumbs as $breadcrumb) { ?>
+    <?php echo $breadcrumb['separator']; ?><a href="<?php echo $breadcrumb['href']; ?>"><?php echo $breadcrumb['text']; ?></a>
+  <?php } ?>
+  </div>
+  <?php if ($error_warning) { ?>
+    <div class="warning"><?php echo $error_warning; ?></div>
+  <?php } ?>
+  <?php if ($success) { ?>
+    <div class="success"><?php echo $success; ?></div>
+  <?php } ?>
+  <div class="box">
+    <div class="heading">
+      <h1><img src="view/image/offer.png" alt="" /> <?php echo $heading_title; ?></h1>
+      <div class="buttons">
+        <a href="<?php echo $insert; ?>" class="button"><?php echo $button_insert; ?></a>
+        <a onclick="$('form').attr('action','<?php echo $delete; ?>'); $('form').submit();" class="button-delete"><?php echo $button_delete; ?></a>
+      </div>
+    </div>
+    <div class="content">
+    <?php if ($navigation_hi) { ?>
+      <div class="pagination" style="margin-bottom:10px;"><?php echo $pagination; ?></div>
+    <?php } ?>
+    <form action="<?php echo $delete; ?>" method="post" enctype="multipart/form-data" id="form">
+      <table class="list">
+        <thead>
+          <tr>
+            <td width="1" style="text-align:center;"><input type="checkbox" onclick="$('input[name*=\'selected\']').attr('checked', this.checked);" id="check-all" class="checkbox" />
+            <label for="check-all"><span></span></label></td>
+            <td class="left"><?php if ($sort == 'name') { ?>
+              <a href="<?php echo $sort_name; ?>" class="<?php echo strtolower($order); ?>"><?php echo $column_name; ?></a>
+            <?php } else { ?>
+              <a href="<?php echo $sort_name; ?>"><?php echo $column_name; ?>&nbsp;&nbsp;<img src="view/image/sort.png" alt="" /></a>
+            <?php } ?></td>
+            <td class="left"><?php if ($sort == 'code') { ?>
+              <a href="<?php echo $sort_code; ?>" class="<?php echo strtolower($order); ?>"><?php echo $column_code; ?></a>
+            <?php } else { ?>
+              <a href="<?php echo $sort_code; ?>"><?php echo $column_code; ?>&nbsp;&nbsp;<img src="view/image/sort.png" alt="" /></a>
+            <?php } ?></td>
+            <td class="left"><?php if ($sort == 'discount') { ?>
+              <a href="<?php echo $sort_discount; ?>" class="<?php echo strtolower($order); ?>"><?php echo $column_discount; ?></a>
+            <?php } else { ?>
+              <a href="<?php echo $sort_discount; ?>"><?php echo $column_discount; ?>&nbsp;&nbsp;<img src="view/image/sort.png" alt="" /></a>
+            <?php } ?></td>
+            <td class="left"><?php if ($sort == 'date_start') { ?>
+              <a href="<?php echo $sort_date_start; ?>" class="<?php echo strtolower($order); ?>"><?php echo $column_date_start; ?></a>
+            <?php } else { ?>
+              <a href="<?php echo $sort_date_start; ?>"><?php echo $column_date_start; ?>&nbsp;&nbsp;<img src="view/image/sort.png" alt="" /></a>
+            <?php } ?></td>
+            <td class="left"><?php if ($sort == 'date_end') { ?>
+              <a href="<?php echo $sort_date_end; ?>" class="<?php echo strtolower($order); ?>"><?php echo $column_date_end; ?></a>
+            <?php } else { ?>
+              <a href="<?php echo $sort_date_end; ?>"><?php echo $column_date_end; ?>&nbsp;&nbsp;<img src="view/image/sort.png" alt="" /></a>
+            <?php } ?></td>
+            <td class="left"><?php if ($sort == 'status') { ?>
+              <a href="<?php echo $sort_status; ?>" class="<?php echo strtolower($order); ?>"><?php echo $column_status; ?></a>
+            <?php } else { ?>
+              <a href="<?php echo $sort_status; ?>"><?php echo $column_status; ?>&nbsp;&nbsp;<img src="view/image/sort.png" alt="" /></a>
+            <?php } ?></td>
+            <td class="right"><?php echo $column_action; ?></td>
+          </tr>
+        </thead>
+        <tbody>
+        <?php if ($coupons) { ?>
+          <?php foreach ($coupons as $coupon) { ?>
+          <tr>
+            <td style="text-align:center;"><?php if (in_array($coupon['coupon_id'], $selected)) { ?>
+              <input type="checkbox" name="selected[]" value="<?php echo $coupon['coupon_id']; ?>" id="<?php echo $coupon['coupon_id']; ?>" class="checkbox" checked />
+              <label for="<?php echo $coupon['coupon_id']; ?>"><span></span></label>
+            <?php } else { ?>
+              <input type="checkbox" name="selected[]" value="<?php echo $coupon['coupon_id']; ?>" id="<?php echo $coupon['coupon_id']; ?>" class="checkbox" />
+              <label for="<?php echo $coupon['coupon_id']; ?>"><span></span></label>
+            <?php } ?></td>
+            <td class="left"><?php echo $coupon['name']; ?></td>
+            <td class="center"><?php echo $coupon['code']; ?></td>
+            <td class="center"><?php echo $coupon['discount']; ?> <?php echo $coupon['type']; ?></td>
+            <td class="center"><?php echo $coupon['date_start']; ?></td>
+            <td class="center"><?php echo $coupon['date_end']; ?></td>
+            <?php if ($coupon['status'] == 1) { ?>
+              <td class="center"><span class="enabled"><?php echo $text_enabled; ?></span></td>
+            <?php } else { ?>
+              <td class="center"><span class="disabled"><?php echo $text_disabled; ?></span></td>
+            <?php } ?>
+            <td class="right"><?php foreach ($coupon['action'] as $action) { ?>
+              <a href="<?php echo $action['href']; ?>" class="button-form"><?php echo $action['text']; ?></a>
+            <?php } ?></td>
+          </tr>
+          <?php } ?>
+        <?php } else { ?>
+          <tr>
+            <td class="center" colspan="8"><?php echo $text_no_results; ?></td>
+          </tr>
+        <?php } ?>
+        </tbody>
+      </table>
+    </form>
+    <?php if ($navigation_lo) { ?>
+      <div class="pagination"><?php echo $pagination; ?></div>
+    <?php } ?>
+    </div>
+  </div>
+</div>
+<?php echo $footer; ?>

--- a/upload/admin/view/template/marketing/marketing_form.tpl
+++ b/upload/admin/view/template/marketing/marketing_form.tpl
@@ -1,0 +1,70 @@
+<?php echo $header; ?>
+<div id="content">
+  <div class="breadcrumb">
+  <?php foreach ($breadcrumbs as $breadcrumb) { ?>
+    <?php echo $breadcrumb['separator']; ?><a href="<?php echo $breadcrumb['href']; ?>"><?php echo $breadcrumb['text']; ?></a>
+  <?php } ?>
+  </div>
+  <?php if ($error_warning) { ?>
+    <div class="warning"><?php echo $error_warning; ?></div>
+  <?php } ?>
+  <?php if ($success) { ?>
+    <div class="success"><?php echo $success; ?></div>
+  <?php } ?>
+  <div class="box">
+    <div class="heading">
+      <h1><img src="view/image/offer.png" alt="" /> <?php echo $heading_title; ?></h1>
+      <div class="buttons">
+        <a onclick="$('#form').submit();" class="button-save"><?php echo $button_save; ?></a>
+        <a onclick="apply();" class="button-save"><?php echo $button_apply; ?></a>
+        <a href="<?php echo $cancel; ?>" class="button-cancel"><?php echo $button_cancel; ?></a>
+      </div>
+    </div>
+    <div class="content">
+    <form action="<?php echo $action; ?>" method="post" enctype="multipart/form-data" id="form">
+      <table class="form">
+        <tbody>
+          <tr>
+            <td><span class="required">*</span>&nbsp;<label for="input-name"><?php echo $entry_name; ?></label></td>
+            <td><?php if ($error_name) { ?>
+              <input type="text" name="name" id="input-name" value="<?php echo $name; ?>" class="input-error" />
+              <span class="error"><?php echo $error_name; ?></span>
+            <?php } else { ?>
+              <input type="text" name="name" id="input-name" value="<?php echo $name; ?>" size="50" />
+            <?php } ?></td>
+          </tr>
+          <tr>
+            <td><label for="input-description"><?php echo $entry_description; ?></label></td>
+            <td><textarea name="description" id="input-description" cols="125" rows="5"><?php echo $description; ?></textarea></td>
+          </tr>
+          <tr>
+            <td><span class="required">*</span> <label for="input-code"><?php echo $entry_code; ?><br /><span class="help"><?php echo $help_code; ?></span></label></td>
+            <td><?php if ($error_code) { ?>
+              <input type="text" name="code" id="input-code" value="<?php echo $code; ?>" class="input-error" />
+              <span class="error"><?php echo $error_code; ?></span>
+            <?php } else { ?>
+              <input type="text" name="code" id="input-code" value="<?php echo $code; ?>" size="50" />
+            <?php } ?></td>
+          </tr>
+          <tr>
+            <td><label for="input-example"><?php echo $entry_example; ?><br /><span class="help"><?php echo $help_example; ?></span></label></td>
+            <td><input type="text" name="example1" id="input-example1" value="" size="125" /><br />
+                <input type="text" name="example2" id="input-example2" value="" size="125" />
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </form>
+    </div>
+  </div>
+</div>
+
+<script type="text/javascript"><!--
+$('#input-code').on('keyup', function() {
+  $('#input-example1').val('<?php echo $store; ?>?tracking=' + $('#input-code').val());
+  $('#input-example2').val('<?php echo $store; ?>index.php?route=common/home&tracking=' + $('#input-code').val());
+});
+
+$('#input-code').trigger('keyup');
+//--></script></div>
+<?php echo $footer; ?>

--- a/upload/admin/view/template/marketing/marketing_list.tpl
+++ b/upload/admin/view/template/marketing/marketing_list.tpl
@@ -1,0 +1,130 @@
+<?php echo $header; ?>
+<div id="content">
+  <div class="breadcrumb">
+  <?php foreach ($breadcrumbs as $breadcrumb) { ?>
+    <?php echo $breadcrumb['separator']; ?><a href="<?php echo $breadcrumb['href']; ?>"><?php echo $breadcrumb['text']; ?></a>
+  <?php } ?>
+  </div>
+  <?php if ($error_warning) { ?>
+    <div class="warning"><?php echo $error_warning; ?></div>
+  <?php } ?>
+  <?php if ($success) { ?>
+    <div class="success"><?php echo $success; ?></div>
+  <?php } ?>
+  <div class="box">
+    <div class="heading">
+      <h1><img src="view/image/offer.png" alt="" /> <?php echo $heading_title; ?></h1>
+      <div class="buttons">
+        <a href="<?php echo $insert; ?>" class="button"><?php echo $button_insert; ?></a>
+        <a onclick="$('form').attr('action','<?php echo $delete; ?>'); $('form').submit();" class="button-delete"><?php echo $button_delete; ?></a>
+      </div>
+    </div>
+    <div class="content">
+    <?php if ($navigation_hi) { ?>
+      <div class="pagination" style="margin-bottom:10px;"><?php echo $pagination; ?></div>
+    <?php } ?>
+    <form action="<?php echo $delete; ?>" method="post" enctype="multipart/form-data" id="form">
+      <table class="list">
+        <thead>
+         <thead>
+          <tr>
+            <td width="1" style="text-align:center;"><input type="checkbox" onclick="$('input[name*=\'selected\']').attr('checked', this.checked);" id="check-all" class="checkbox" />
+            <label for="check-all"><span></span></label></td>
+            <td class="left"><?php if ($sort == 'name') { ?>
+              <a href="<?php echo $sort_name; ?>" class="<?php echo strtolower($order); ?>"><?php echo $column_name; ?></a>
+            <?php } else { ?>
+              <a href="<?php echo $sort_name; ?>"><?php echo $column_name; ?>&nbsp;&nbsp;<img src="view/image/sort.png" alt="" /></a>
+            <?php } ?></td>
+            <td class="left"><?php if ($sort == 'code') { ?>
+              <a href="<?php echo $sort_code; ?>" class="<?php echo strtolower($order); ?>"><?php echo $column_code; ?></a>
+              <?php } else { ?>
+              <a href="<?php echo $sort_code; ?>"><?php echo $column_code; ?></a>
+              <?php } ?></td>
+            <td class="right"><?php echo $column_clicks; ?></td>
+            <td class="right"><?php echo $column_orders; ?></td>
+            <td class="center"><?php if ($sort == 'date_added') { ?>
+              <a href="<?php echo $sort_date_added; ?>" class="<?php echo strtolower($order); ?>"><?php echo $column_date_added; ?></a>
+              <?php } else { ?>
+              <a href="<?php echo $sort_date_added; ?>"><?php echo $column_date_added; ?></a>
+              <?php } ?></td>
+            <td class="right"><?php echo $column_action; ?></td>
+          </tr>
+        </thead>
+        <tbody>
+        <tr class="filter">
+          <td></td>
+          <td><input type="text" name="filter_name" value="<?php echo $filter_name; ?>" /></td>
+          <td><input type="text" name="filter_code" value="<?php echo $filter_code; ?>" /></td>
+          <td>&nbsp;</td>
+          <td>&nbsp;</td>
+          <td class="center"><input type="text" name="filter_date_added" value="<?php echo $filter_date_added; ?>" size="12" id="date" /></td>
+          <td class="right"><a onclick="filter();" class="button-filter"><?php echo $button_filter; ?></a></td>
+        </tr>
+        <?php if ($marketings) { ?>
+          <?php foreach ($marketings as $marketing) { ?>
+          <tr>
+            <td style="text-align:center;"><?php if (in_array($marketing['marketing_id'], $selected)) { ?>
+              <input type="checkbox" name="selected[]" value="<?php echo $marketing['marketing_id']; ?>" id="<?php echo $marketing['marketing_id']; ?>" class="checkbox" checked />
+              <label for="<?php echo $marketing['marketing_id']; ?>"><span></span></label>
+            <?php } else { ?>
+              <input type="checkbox" name="selected[]" value="<?php echo $marketing['marketing_id']; ?>" id="<?php echo $marketing['marketing_id']; ?>" class="checkbox" />
+              <label for="<?php echo $marketing['marketing_id']; ?>"><span></span></label>
+            <?php } ?></td>
+            <td class="left"><?php echo $marketing['name']; ?></td>
+            <td class="left"><?php echo $marketing['code']; ?></td>
+            <td class="right"><?php echo $marketing['clicks']; ?></td>
+            <td class="right"><?php echo $marketing['orders']; ?></td>
+            <td class="center"><?php echo $marketing['date_added']; ?></td>
+            <td class="right"><?php foreach ($marketing['action'] as $action) { ?>
+              <a href="<?php echo $action['href']; ?>" class="button-form"><?php echo $action['text']; ?></a>
+            <?php } ?></td>
+          </tr>
+          <?php } ?>
+        <?php } else { ?>
+          <tr>
+            <td class="center" colspan="7"><?php echo $text_no_results; ?></td>
+          </tr>
+        <?php } ?>
+        </tbody>
+      </table>
+    </form>
+    <?php if ($navigation_lo) { ?>
+      <div class="pagination"><?php echo $pagination; ?></div>
+    <?php } ?>
+    </div>
+  </div>
+</div>
+<?php echo $footer; ?>
+
+<script type="text/javascript"><!--
+function filter() {
+  url = 'index.php?route=marketing/marketing&token=<?php echo $token; ?>';
+  
+  var filter_name = $('input[name=\'filter_name\']').val();
+  
+  if (filter_name) {
+    url += '&filter_name=' + encodeURIComponent(filter_name);
+  }
+  
+  var filter_code = $('input[name=\'filter_code\']').val();
+  
+  if (filter_code) {
+    url += '&filter_code=' + encodeURIComponent(filter_code);
+  }
+    
+  var filter_date_added = $('input[name=\'filter_date_added\']').val();
+  
+  if (filter_date_added) {
+    url += '&filter_date_added=' + encodeURIComponent(filter_date_added);
+  }
+ 
+  location = url;
+}
+//--></script>
+
+<script type="text/javascript"><!--
+$(document).ready(function() {
+  $('#date').datepicker({dateFormat: 'yy-mm-dd'});
+});
+//--></script>
+<?php echo $footer; ?>

--- a/upload/admin/view/template/report/affiliate.tpl
+++ b/upload/admin/view/template/report/affiliate.tpl
@@ -18,8 +18,8 @@
     <?php } ?>
       <div class="report">
         <div class="left"><img src="view/image/filter.png" alt="" /></div>
-        <div class="left"><?php echo $entry_date_start; ?> <input type="text" name="filter_date_start" value="<?php echo $filter_date_start; ?>" id="date-start" size="12" /> <img src="view/image/calendar.png" alt="" /></div>
-        <div class="left"><?php echo $entry_date_end; ?> <input type="text" name="filter_date_end" value="<?php echo $filter_date_end; ?>" id="date-end" size="12" /> <img src="view/image/calendar.png" alt="" /></div>
+        <div class="left"><?php echo $entry_date_start; ?> <input type="text" name="filter_date_start" value="<?php echo $filter_date_start; ?>" id="input-date-start" size="12" /> <img src="view/image/calendar.png" alt="" /></div>
+        <div class="left"><?php echo $entry_date_end; ?> <input type="text" name="filter_date_end" value="<?php echo $filter_date_end; ?>" id="input-date-end" size="12" /> <img src="view/image/calendar.png" alt="" /></div>
         <div class="right"><a onclick="filter();" class="button-filter"><?php echo $button_filter; ?></a></div>
       </div>
       <table class="list">
@@ -85,8 +85,8 @@ function filter() {
 
 <script type="text/javascript"><!--
 $(document).ready(function() {
-  $('#date-start').datepicker({dateFormat: 'yy-mm-dd'});
-  $('#date-end').datepicker({dateFormat: 'yy-mm-dd'});
+  $('#input-date-start').datepicker({dateFormat: 'yy-mm-dd'});
+  $('#input-date-end').datepicker({dateFormat: 'yy-mm-dd'});
 });
 //--></script>
 

--- a/upload/admin/view/template/report/affiliate_activity.tpl
+++ b/upload/admin/view/template/report/affiliate_activity.tpl
@@ -18,32 +18,25 @@
     <?php } ?>
       <div class="report">
         <div class="left"><img src="view/image/filter.png" alt="" /></div>
-        <div class="left"><?php echo $entry_date_start; ?> <input type="text" name="filter_date_start" value="<?php echo $filter_date_start; ?>" id="date-start" size="12" /> <img src="view/image/calendar.png" alt="" /></div>
-        <div class="left"><?php echo $entry_date_end; ?> <input type="text" name="filter_date_end" value="<?php echo $filter_date_end; ?>" id="date-end" size="12" /> <img src="view/image/calendar.png" alt="" /></div>
+        <div class="left"><?php echo $entry_date_start; ?> <input type="text" name="filter_date_start" value="<?php echo $filter_date_start; ?>" id="input-date-start" size="12" /> <img src="view/image/calendar.png" alt="" /></div>
+        <div class="left"><?php echo $entry_date_end; ?> <input type="text" name="filter_date_end" value="<?php echo $filter_date_end; ?>" id="input-date-end" size="12" /> <img src="view/image/calendar.png" alt="" /></div>
         <div class="right"><a onclick="filter();" class="button-filter"><?php echo $button_filter; ?></a></div>
       </div>
       <table class="list">
         <thead>
           <tr>
-            <td class="left"><?php echo $column_affiliate; ?></td>
-            <td class="left"><?php echo $column_email; ?></td>
-            <td class="left"><?php echo $column_status; ?></td>
-            <td class="right"><?php echo $column_commission; ?></td>
-            <td class="right"><?php echo $column_orders; ?></td>
-            <td class="right"><?php echo $column_total; ?></td>
-            <td class="right"><?php echo $column_action; ?></td>
+            <td class="left"><?php echo $column_comment; ?></td>
+            <td class="left"><?php echo $column_ip; ?></td>
+            <td class="left"><?php echo $column_date_added; ?></td>
           </tr>
         </thead>
         <tbody>
-        <?php if ($affiliates) { ?>
-          <?php foreach ($affiliates as $affiliate) { ?>
+        <?php if ($activities) { ?>
+          <?php foreach ($activities as $activity) { ?>
           <tr>
-            <td class="left"><?php echo $affiliate['affiliate']; ?></td>
-            <td class="left"><?php echo $affiliate['email']; ?></td>
-            <td class="left"><?php echo $affiliate['status']; ?></td>
-            <td class="right"><?php echo $affiliate['commission']; ?></td>
-            <td class="right"><?php echo $affiliate['orders']; ?></td>
-            <td class="right"><?php echo $affiliate['total']; ?></td>
+            <td class="left"><?php echo $activity['comment']; ?></td>
+            <td class="left"><?php echo $activity['ip']; ?></td>
+            <td class="left"><?php echo $activity['date_added']; ?></td>
             <td class="right"><?php foreach ($affiliate['action'] as $action) { ?>
               <a href="<?php echo $action['href']; ?>" class="button-form"><?php echo $action['text']; ?></a>
             <?php } ?></td>
@@ -51,7 +44,7 @@
         <?php } ?>
       <?php } else { ?>
         <tr>
-          <td class="center" colspan="7"><?php echo $text_no_results; ?></td>
+          <td class="center" colspan="4"><?php echo $text_no_results; ?></td>
         </tr>
       <?php } ?>
       </tbody>
@@ -65,7 +58,18 @@
 
 <script type="text/javascript"><!--
 function filter() {
-  url = 'index.php?route=report/affiliate_commission&token=<?php echo $token; ?>';
+  url = 'index.php?route=report/affiliate_activity&token=<?php echo $token; ?>';
+
+  var filter_affiliate = $('input[name=\'filter_affiliate\']').val();
+
+  if (filter_affiliate) {
+    url += '&filter_affiliate=' + encodeURIComponent(filter_affiliate);
+  }
+  var filter_ip = $('input[name=\'filter_ip\']').val();
+
+  if (filter_ip) {
+    url += '&filter_ip=' + encodeURIComponent(filter_ip);
+  }
 
   var filter_date_start = $('input[name=\'filter_date_start\']').attr('value');
 
@@ -85,8 +89,8 @@ function filter() {
 
 <script type="text/javascript"><!--
 $(document).ready(function() {
-  $('#date-start').datepicker({dateFormat: 'yy-mm-dd'});
-  $('#date-end').datepicker({dateFormat: 'yy-mm-dd'});
+  $('#input-date-start').datepicker({dateFormat: 'yy-mm-dd'});
+  $('#input-date-end').datepicker({dateFormat: 'yy-mm-dd'});
 });
 //--></script>
 

--- a/upload/admin/view/template/report/marketing.tpl
+++ b/upload/admin/view/template/report/marketing.tpl
@@ -1,0 +1,103 @@
+<?php echo $header; ?>
+<div id="content">
+  <div class="breadcrumb">
+  <?php foreach ($breadcrumbs as $breadcrumb) { ?>
+    <?php echo $breadcrumb['separator']; ?><a href="<?php echo $breadcrumb['href']; ?>"><?php echo $breadcrumb['text']; ?></a>
+  <?php } ?>
+  </div>
+  <div class="box">
+    <div class="heading">
+      <h1><img src="view/image/report.png" alt="" /> <?php echo $heading_title; ?></h1>
+      <div class="buttons">
+        <a onclick="location = '<?php echo $close; ?>';" class="button-cancel"><?php echo $button_close; ?></a>
+      </div>
+    </div>
+    <div class="content">
+    <?php if ($navigation_hi) { ?>
+      <div class="pagination" style="margin-bottom:10px;"><?php echo $pagination; ?></div>
+    <?php } ?>
+      <div class="report">
+        <div class="left"><img src="view/image/filter.png" alt="" /></div>
+        <div class="left"><?php echo $entry_date_start; ?> <input type="text" name="filter_date_start" value="<?php echo $filter_date_start; ?>" id="input-date-start" size="12" /> <img src="view/image/calendar.png" alt="" /></div>
+        <div class="left"><?php echo $entry_date_end; ?> <input type="text" name="filter_date_end" value="<?php echo $filter_date_end; ?>" id="input-date-end" size="12" /> <img src="view/image/calendar.png" alt="" /></div>
+        <div class="left"><?php echo $entry_status; ?> <select name="filter_order_status_id" id="input-status">
+          <option value="0"><?php echo $text_all_status; ?></option>
+          <?php foreach ($order_statuses as $order_status) { ?>
+            <?php if ($order_status['order_status_id'] == $filter_order_status_id) { ?>
+              <option value="<?php echo $order_status['order_status_id']; ?>" selected="selected"><?php echo $order_status['name']; ?></option>
+            <?php } else { ?>
+              <option value="<?php echo $order_status['order_status_id']; ?>"><?php echo $order_status['name']; ?></option>
+            <?php } ?>
+          <?php } ?>
+        </select></div>
+        <div class="right"><a onclick="filter();" class="button-filter"><?php echo $button_filter; ?></a></div>
+      </div>
+      <table class="list">
+        <thead>
+          <tr>
+            <td class="left"><?php echo $column_campaign; ?></td>
+            <td class="left"><?php echo $column_code; ?></td>
+            <td class="right"><?php echo $column_clicks; ?></td>
+            <td class="right"><?php echo $column_orders; ?></td>
+            <td class="right"><?php echo $column_total; ?></td>
+          </tr>
+        </thead>
+        <tbody>
+          <?php if ($marketings) { ?>
+          <?php foreach ($marketings as $marketing) { ?>
+          <tr>
+            <td class="left"><?php echo $marketing['campaign']; ?></td>
+            <td class="left"><?php echo $marketing['code']; ?></td>
+            <td class="right"><?php echo $marketing['clicks']; ?></td>
+            <td class="right"><?php echo $marketing['orders']; ?></td>
+            <td class="right"><?php echo $marketing['total']; ?></td>
+          </tr>
+          <?php } ?>
+          <?php } else { ?>
+          <tr>
+            <td class="center" colspan="5"><?php echo $text_no_results; ?></td>
+          </tr>
+          <?php } ?>
+      </tbody>
+      </table>
+    <?php if ($navigation_lo) { ?>
+      <div class="pagination"><?php echo $pagination; ?></div>
+    <?php } ?>
+    </div>
+  </div>
+</div>
+
+<script type="text/javascript"><!--
+function filter() {
+  url = 'index.php?route=report/marketing&token=<?php echo $token; ?>';
+
+  var filter_date_start = $('input[name=\'filter_date_start\']').attr('value');
+
+  if (filter_date_start) {
+    url += '&filter_date_start=' + encodeURIComponent(filter_date_start);
+  }
+
+  var filter_date_end = $('input[name=\'filter_date_end\']').attr('value');
+
+  if (filter_date_end) {
+    url += '&filter_date_end=' + encodeURIComponent(filter_date_end);
+  }
+
+  var filter_order_status_id = $('select[name=\'filter_order_status_id\']').val();
+
+  if (filter_order_status_id != 0) {
+    url += '&filter_order_status_id=' + encodeURIComponent(filter_order_status_id);
+  }
+
+  location = url;
+}
+//--></script>
+
+<script type="text/javascript"><!--
+$(document).ready(function() {
+  $('#input-date-start').datepicker({dateFormat: 'yy-mm-dd'});
+  $('#input-date-end').datepicker({dateFormat: 'yy-mm-dd'});
+});
+//--></script>
+
+<?php echo $footer; ?>

--- a/upload/catalog/model/checkout/marketing.php
+++ b/upload/catalog/model/checkout/marketing.php
@@ -1,0 +1,9 @@
+<?php
+class ModelCheckoutMarketing extends Model {
+	public function getMarketingByCode($code) {
+		$query = $this->db->query("SELECT * FROM " . DB_PREFIX . "marketing WHERE code = '" . $this->db->escape($code) . "'");
+
+		return $query->row;
+	}
+}
+?>

--- a/upload/install/opencart-clean.sql
+++ b/upload/install/opencart-clean.sql
@@ -76,6 +76,42 @@ CREATE TABLE `oc_affiliate` (
 -- --------------------------------------------------------
 
 --
+-- Table structure for table `oc_affiliate_activity`
+--
+
+DROP TABLE IF EXISTS `oc_affiliate_activity`;
+CREATE TABLE `oc_affiliate_activity` (
+  `affiliate_activity_id` int(11) NOT NULL AUTO_INCREMENT,
+  `affiliate_id` int(11) NOT NULL,
+  `key` varchar(64) NOT NULL,
+  `data` text CHARACTER SET utf8 NOT NULL,
+  `ip` varchar(40) NOT NULL,
+  `date_added` datetime NOT NULL,
+  PRIMARY KEY (`affiliate_activity_id`)
+) ENGINE=MyISAM DEFAULT CHARSET=utf8 COLLATE=utf8_general_ci;
+
+-- --------------------------------------------------------
+
+--
+-- Table structure for table `oc_affiliate_login`
+--
+
+DROP TABLE IF EXISTS `oc_affiliate_login`;
+CREATE TABLE `oc_affiliate_login` (
+  `affiliate_login_id` int(11) NOT NULL AUTO_INCREMENT,
+  `email` varchar(96) NOT NULL,
+  `ip` varchar(40) NOT NULL,
+  `total` int(4) NOT NULL,
+  `date_added` datetime NOT NULL,
+  `date_modified` datetime NOT NULL,
+  PRIMARY KEY (`affiliate_login_id`),
+  KEY `email` (`email`),
+  KEY `ip` (`ip`)
+) ENGINE=MyISAM DEFAULT CHARSET=utf8 COLLATE=utf8_general_ci;
+
+-- --------------------------------------------------------
+
+--
 -- Table structure for table `oc_affiliate_transaction`
 --
 
@@ -1574,7 +1610,7 @@ CREATE TABLE `oc_information_description` (
   `title` varchar(64) NOT NULL,
   `meta_description` varchar(255) NOT NULL,
   `meta_keyword` varchar(255) NOT NULL,
-  `description` text NOT NULL,
+  `description` text CHARACTER SET utf8 NOT NULL,
   PRIMARY KEY (`information_id`,`language_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=utf8 COLLATE=utf8_general_ci;
 
@@ -1807,6 +1843,23 @@ CREATE TABLE `oc_manufacturer_to_store` (
   `manufacturer_id` int(11) NOT NULL,
   `store_id` int(11) NOT NULL,
   PRIMARY KEY (`manufacturer_id`,`store_id`)
+) ENGINE=MyISAM DEFAULT CHARSET=utf8 COLLATE=utf8_general_ci;
+
+-- --------------------------------------------------------
+
+--
+-- Table structure for table `oc_marketing`
+--
+
+DROP TABLE IF EXISTS `oc_marketing`;
+CREATE TABLE `oc_marketing` (
+  `marketing_id` int(11) NOT NULL AUTO_INCREMENT,
+  `name` varchar(32) NOT NULL,
+  `description` text NOT NULL,
+  `code` varchar(64) NOT NULL,
+  `clicks` int(5) NOT NULL DEFAULT '0',
+  `date_added` datetime NOT NULL,
+  PRIMARY KEY (`marketing_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=utf8 COLLATE=utf8_general_ci;
 
 -- --------------------------------------------------------
@@ -2461,7 +2514,7 @@ CREATE TABLE `oc_product_attribute` (
   `product_id` int(11) NOT NULL,
   `attribute_id` int(11) NOT NULL,
   `language_id` int(11) NOT NULL,
-  `text` text NOT NULL,
+  `text` text CHARACTER SET utf8 NOT NULL,
   PRIMARY KEY (`product_id`,`attribute_id`,`language_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=utf8 COLLATE=utf8_general_ci;
 

--- a/upload/install/opencart-upgrade.sql
+++ b/upload/install/opencart-upgrade.sql
@@ -76,6 +76,42 @@ CREATE TABLE `oc_affiliate` (
 -- --------------------------------------------------------
 
 --
+-- Table structure for table `oc_affiliate_activity`
+--
+
+DROP TABLE IF EXISTS `oc_affiliate_activity`;
+CREATE TABLE `oc_affiliate_activity` (
+  `date_added` datetime NOT NULL,
+  `ip` varchar(40) NOT NULL,
+  `data` text CHARACTER SET utf8 NOT NULL,
+  `key` varchar(64) NOT NULL,
+  `affiliate_id` int(11) NOT NULL,
+  `affiliate_activity_id` int(11) NOT NULL AUTO_INCREMENT,
+  PRIMARY KEY (`affiliate_activity_id`)
+) ENGINE=MyISAM DEFAULT CHARSET=utf8 COLLATE=utf8_general_ci;
+
+-- --------------------------------------------------------
+
+--
+-- Table structure for table `oc_affiliate_login`
+--
+
+DROP TABLE IF EXISTS `oc_affiliate_login`;
+CREATE TABLE `oc_affiliate_login` (
+  `date_modified` datetime NOT NULL,
+  `date_added` datetime NOT NULL,
+  `total` int(4) NOT NULL,
+  `ip` varchar(40) NOT NULL,
+  `email` varchar(96) NOT NULL,
+  `affiliate_login_id` int(11) NOT NULL AUTO_INCREMENT,
+  PRIMARY KEY (`affiliate_login_id`),
+  KEY `email` (`email`),
+  KEY `ip` (`ip`)
+) ENGINE=MyISAM DEFAULT CHARSET=utf8 COLLATE=utf8_general_ci;
+
+-- --------------------------------------------------------
+
+--
 -- Table structure for table `oc_affiliate_transaction`
 --
 

--- a/upload/install/opencart.sql
+++ b/upload/install/opencart.sql
@@ -76,6 +76,42 @@ CREATE TABLE `oc_affiliate` (
 -- --------------------------------------------------------
 
 --
+-- Table structure for table `oc_affiliate_activity`
+--
+
+DROP TABLE IF EXISTS `oc_affiliate_activity`;
+CREATE TABLE `oc_affiliate_activity` (
+  `affiliate_activity_id` int(11) NOT NULL AUTO_INCREMENT,
+  `affiliate_id` int(11) NOT NULL,
+  `key` varchar(64) NOT NULL,
+  `data` text CHARACTER SET utf8 NOT NULL,
+  `ip` varchar(40) NOT NULL,
+  `date_added` datetime NOT NULL,
+  PRIMARY KEY (`affiliate_activity_id`)
+) ENGINE=MyISAM DEFAULT CHARSET=utf8 COLLATE=utf8_general_ci;
+
+-- --------------------------------------------------------
+
+--
+-- Table structure for table `oc_affiliate_login`
+--
+
+DROP TABLE IF EXISTS `oc_affiliate_login`;
+CREATE TABLE `oc_affiliate_login` (
+  `affiliate_login_id` int(11) NOT NULL AUTO_INCREMENT,
+  `email` varchar(96) NOT NULL,
+  `ip` varchar(40) NOT NULL,
+  `total` int(4) NOT NULL,
+  `date_added` datetime NOT NULL,
+  `date_modified` datetime NOT NULL,
+  PRIMARY KEY (`affiliate_login_id`),
+  KEY `email` (`email`),
+  KEY `ip` (`ip`)
+) ENGINE=MyISAM DEFAULT CHARSET=utf8 COLLATE=utf8_general_ci;
+
+-- --------------------------------------------------------
+
+--
 -- Table structure for table `oc_affiliate_transaction`
 --
 
@@ -2281,6 +2317,23 @@ INSERT INTO `oc_manufacturer_to_store` (`manufacturer_id`, `store_id`) VALUES
 -- --------------------------------------------------------
 
 --
+-- Table structure for table `oc_marketing`
+--
+
+DROP TABLE IF EXISTS `oc_marketing`;
+CREATE TABLE `oc_marketing` (
+  `marketing_id` int(11) NOT NULL AUTO_INCREMENT,
+  `name` varchar(32) NOT NULL,
+  `description` text NOT NULL,
+  `code` varchar(64) NOT NULL,
+  `clicks` int(5) NOT NULL DEFAULT '0',
+  `date_added` datetime NOT NULL,
+  PRIMARY KEY (`marketing_id`)
+) ENGINE=MyISAM DEFAULT CHARSET=utf8 COLLATE=utf8_general_ci;
+
+-- --------------------------------------------------------
+
+--
 -- Table structure for table `oc_menu`
 --
 
@@ -2804,6 +2857,8 @@ CREATE TABLE `oc_order` (
   `order_status_id` int(11) NOT NULL DEFAULT '0',
   `affiliate_id` int(11) NOT NULL,
   `commission` decimal(15,4) NOT NULL,
+  `marketing_id` int(11) NOT NULL,
+  `tracking` varchar(64) NOT NULL,
   `language_id` int(11) NOT NULL,
   `currency_id` int(11) NOT NULL,
   `currency_code` varchar(3) NOT NULL,
@@ -2866,7 +2921,7 @@ CREATE TABLE `oc_order_option` (
   `product_option_id` int(11) NOT NULL,
   `product_option_value_id` int(11) NOT NULL DEFAULT '0',
   `name` varchar(255) NOT NULL,
-  `value` text NOT NULL,
+  `value` text CHARACTER SET utf8 NOT NULL,
   `type` varchar(32) NOT NULL,
   PRIMARY KEY (`order_option_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=utf8 COLLATE=utf8_general_ci;
@@ -3976,7 +4031,7 @@ CREATE TABLE `oc_setting` (
   `store_id` int(11) NOT NULL DEFAULT '0',
   `group` varchar(32) NOT NULL,
   `key` varchar(64) NOT NULL,
-  `value` text NOT NULL,
+  `value` text CHARACTER SET utf8 NOT NULL,
   `serialized` tinyint(1) NOT NULL,
   PRIMARY KEY (`setting_id`)
 ) ENGINE=MyISAM DEFAULT CHARSET=utf8 COLLATE=utf8_general_ci;


### PR DESCRIPTION
This is the marketing admin menu from oc2.x
Affiliates, contact and coupons have been their code updated to oc2.2.0.0

I have moved the files from the 'sale' directory to a new 'marketing' directory, exactly as in oc2.x and in Arastta.
So extensions for oc1.5 will need to be adapted as they will not find the corresponding functions. 

Another solution I didnt follow but possible, would have been keeping the 'sale' directory in code and place new marketing files in it. If you prefer this case, dont apply this patch.